### PR TITLE
Add nullzero to MigratedAt field of migrations table in order to fix …

### DIFF
--- a/migrate/migration.go
+++ b/migrate/migration.go
@@ -18,7 +18,7 @@ type Migration struct {
 	ID         int64
 	Name       string
 	GroupID    int64
-	MigratedAt time.Time `bun:",notnull,default:current_timestamp"`
+	MigratedAt time.Time `bun:",notnull,nullzero,default:current_timestamp"`
 
 	Up   MigrationFunc `bun:"-"`
 	Down MigrationFunc `bun:"-"`


### PR DESCRIPTION
The `migrated_at` column of the `bun_migrations` table was inserting a date that looked suspiciously like time zero. 

By adding the `nullzero` field to the bun tag on the table, we force postgres to use the default, rather than inserting time zero (which does some weird things if you are using a non-UTC timezone due to offset).

I have tested this on a local application, and it does indeed force the `migrated_at` field to be the correct current_timestamp.

Signed-off-by: Andrew Suderman <andrew@sudermanjr.com>