### PR TITLE
Allow ptr of time.Time as SoftDelete filed

### DIFF
--- a/schema/table.go
+++ b/schema/table.go
@@ -859,6 +859,11 @@ func softDeleteFieldUpdater(field *Field) func(fv reflect.Value) error {
 	switch field.Type {
 	case timeType:
 		return func(fv reflect.Value) error {
+			if fv.Kind() == reflect.Ptr {
+				now := time.Now()
+				fv.Set(reflect.ValueOf(&now))
+				return nil
+			}
 			ptr := fv.Addr().Interface().(*time.Time)
 			*ptr = time.Now()
 			return nil


### PR DESCRIPTION

And we still does not allow delete with nil pointer model, such as :
```
-       _, err = db.NewDelete().Model(video1).Where("id = ?", video1.ID).Exec(ctx)
+       _, err = db.NewDelete().Model((*Video)(nil)).Where("id = ?", video1.ID).Exec(ctx)
```

Will we support this?