### PR TITLE
Add MarkDone and MarkUndone

### DIFF
--- a/example/migrate/main.go
+++ b/example/migrate/main.go
@@ -138,7 +138,7 @@ func newDBCommand(migrator *migrate.Migrator) *cli.Command {
 				Name:  "mark_applied",
 				Usage: "mark migrations as applied without actually running them",
 				Action: func(c *cli.Context) error {
-					group, err := migrator.Migrate(c.Context, migrate.WithoutMigrationFunc())
+					group, err := migrator.Migrate(c.Context, migrate.WithNopMigration())
 					if err != nil {
 						return err
 					}
@@ -146,7 +146,7 @@ func newDBCommand(migrator *migrate.Migrator) *cli.Command {
 						fmt.Printf("there are no new migrations to mark as applied\n")
 						return nil
 					}
-					fmt.Printf("marked as completed %s\n", group)
+					fmt.Printf("marked as applied %s\n", group)
 					return nil
 				},
 			},

--- a/example/migrate/main.go
+++ b/example/migrate/main.go
@@ -58,8 +58,8 @@ func newDBCommand(migrator *migrate.Migrator) *cli.Command {
 					if err != nil {
 						return err
 					}
-					if group.ID == 0 {
-						fmt.Printf("there are no new migrations to run\n")
+					if group.IsZero() {
+						fmt.Printf("there are no new migrations to run (database is up to date)\n")
 						return nil
 					}
 					fmt.Printf("migrated to %s\n", group)
@@ -74,7 +74,7 @@ func newDBCommand(migrator *migrate.Migrator) *cli.Command {
 					if err != nil {
 						return err
 					}
-					if group.ID == 0 {
+					if group.IsZero() {
 						fmt.Printf("there are no groups to roll back\n")
 						return nil
 					}
@@ -124,26 +124,26 @@ func newDBCommand(migrator *migrate.Migrator) *cli.Command {
 				Name:  "status",
 				Usage: "print migrations status",
 				Action: func(c *cli.Context) error {
-					status, err := migrator.Status(c.Context)
+					ms, err := migrator.MigrationsWithStatus(c.Context)
 					if err != nil {
 						return err
 					}
-					fmt.Printf("migrations: %s\n", status.Migrations)
-					fmt.Printf("new migrations: %s\n", status.NewMigrations)
-					fmt.Printf("last group: %s\n", status.LastGroup)
+					fmt.Printf("migrations: %s\n", ms)
+					fmt.Printf("unapplied migrations: %s\n", ms.Unapplied())
+					fmt.Printf("last migration group: %s\n", ms.LastGroup())
 					return nil
 				},
 			},
 			{
-				Name:  "mark_completed",
-				Usage: "mark migrations as completed without actually running them",
+				Name:  "mark_applied",
+				Usage: "mark migrations as applied without actually running them",
 				Action: func(c *cli.Context) error {
-					group, err := migrator.MarkCompleted(c.Context)
+					group, err := migrator.Migrate(c.Context, migrate.WithoutMigrationFunc())
 					if err != nil {
 						return err
 					}
-					if group.ID == 0 {
-						fmt.Printf("there are no new migrations to mark as completed\n")
+					if group.IsZero() {
+						fmt.Printf("there are no new migrations to mark as applied\n")
 						return nil
 					}
 					fmt.Printf("marked as completed %s\n", group)

--- a/migrate/migration.go
+++ b/migrate/migration.go
@@ -157,7 +157,7 @@ type MigrationFile struct {
 //------------------------------------------------------------------------------
 
 type migrationConfig struct {
-	dryRun bool
+	withoutMigrationFunc bool
 }
 
 func newMigrationConfig(opts []MigrationOption) *migrationConfig {
@@ -170,8 +170,8 @@ func newMigrationConfig(opts []MigrationOption) *migrationConfig {
 
 type MigrationOption func(cfg *migrationConfig)
 
-func WithMigrationDryRun() MigrationOption {
+func WithoutMigrationFunc() MigrationOption {
 	return func(cfg *migrationConfig) {
-		cfg.dryRun = true
+		cfg.withoutMigrationFunc = true
 	}
 }

--- a/migrate/migration.go
+++ b/migrate/migration.go
@@ -153,3 +153,25 @@ type MigrationFile struct {
 	FilePath string
 	Content  string
 }
+
+//------------------------------------------------------------------------------
+
+type migrationConfig struct {
+	dryRun bool
+}
+
+func newMigrationConfig(opts []MigrationOption) *migrationConfig {
+	cfg := new(migrationConfig)
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	return cfg
+}
+
+type MigrationOption func(cfg *migrationConfig)
+
+func WithMigrationDryRun() MigrationOption {
+	return func(cfg *migrationConfig) {
+		cfg.dryRun = true
+	}
+}

--- a/migrate/migration.go
+++ b/migrate/migration.go
@@ -154,7 +154,7 @@ func (ms MigrationSlice) Applied() MigrationSlice {
 	return applied
 }
 
-// Unrone returns unapplied migrations in ascending order
+// Unapplied returns unapplied migrations in ascending order
 // (the order is important and is used in Migrate).
 func (ms MigrationSlice) Unapplied() MigrationSlice {
 	var unapplied MigrationSlice
@@ -221,7 +221,7 @@ type MigrationFile struct {
 //------------------------------------------------------------------------------
 
 type migrationConfig struct {
-	withoutMigrationFunc bool
+	nop bool
 }
 
 func newMigrationConfig(opts []MigrationOption) *migrationConfig {
@@ -234,9 +234,9 @@ func newMigrationConfig(opts []MigrationOption) *migrationConfig {
 
 type MigrationOption func(cfg *migrationConfig)
 
-func WithoutMigrationFunc() MigrationOption {
+func WithNopMigration() MigrationOption {
 	return func(cfg *migrationConfig) {
-		cfg.withoutMigrationFunc = true
+		cfg.nop = true
 	}
 }
 

--- a/migrate/migrations.go
+++ b/migrate/migrations.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"sort"
 	"strings"
 )
 
@@ -37,11 +36,7 @@ func NewMigrations(opts ...MigrationsOption) *Migrations {
 func (m *Migrations) Sorted() MigrationSlice {
 	migrations := make(MigrationSlice, len(m.ms))
 	copy(migrations, m.ms)
-
-	sort.Slice(migrations, func(i, j int) bool {
-		return migrations[i].Name < migrations[j].Name
-	})
-
+	sortAsc(migrations)
 	return migrations
 }
 

--- a/migrate/migrator.go
+++ b/migrate/migrator.go
@@ -110,7 +110,7 @@ func (m *Migrator) Migrate(ctx context.Context, opts ...MigrationOption) (*Migra
 		migration := &migrations[i]
 		migration.GroupID = group.ID
 
-		if !cfg.dryRun && migration.Up != nil {
+		if !cfg.withoutMigrationFunc && migration.Up != nil {
 			if err := migration.Up(ctx, m.db); err != nil {
 				return nil, err
 			}
@@ -144,7 +144,7 @@ func (m *Migrator) Rollback(ctx context.Context, opts ...MigrationOption) (*Migr
 	for i := range lastGroup.Migrations {
 		migration := &lastGroup.Migrations[i]
 
-		if !cfg.dryRun && migration.Down != nil {
+		if !cfg.withoutMigrationFunc && migration.Down != nil {
 			if err := migration.Down(ctx, m.db); err != nil {
 				return nil, err
 			}
@@ -197,8 +197,8 @@ func (m *Migrator) SelectLastGroup(ctx context.Context) (*MigrationGroup, error)
 func (m *Migrator) MarkCompleted(ctx context.Context) (*MigrationGroup, error) {
 	log.Printf(
 		"DEPRECATED: bun: replace MarkCompleted(ctx) with " +
-			"Migrate(ctx, migrate.WithMigrationDryRun())")
-	return m.Migrate(ctx, WithMigrationDryRun())
+			"Migrate(ctx, migrate.WithoutMigrationFunc())")
+	return m.Migrate(ctx, WithoutMigrationFunc())
 }
 
 type MigrationStatus struct {

--- a/migrate/migrator.go
+++ b/migrate/migrator.go
@@ -124,7 +124,7 @@ func (m *Migrator) Migrate(ctx context.Context, opts ...MigrationOption) (*Migra
 		migration := &group.Migrations[i]
 		migration.GroupID = group.ID
 
-		if !cfg.withoutMigrationFunc && migration.Up != nil {
+		if !cfg.nop && migration.Up != nil {
 			if err := migration.Up(ctx, m.db); err != nil {
 				return nil, err
 			}
@@ -160,7 +160,7 @@ func (m *Migrator) Rollback(ctx context.Context, opts ...MigrationOption) (*Migr
 	for i := range lastGroup.Migrations {
 		migration := &lastGroup.Migrations[i]
 
-		if !cfg.withoutMigrationFunc && migration.Down != nil {
+		if !cfg.nop && migration.Down != nil {
 			if err := migration.Down(ctx, m.db); err != nil {
 				return nil, err
 			}
@@ -199,9 +199,9 @@ func (m *Migrator) Status(ctx context.Context) (*MigrationStatus, error) {
 func (m *Migrator) MarkCompleted(ctx context.Context) (*MigrationGroup, error) {
 	log.Printf(
 		"DEPRECATED: bun: replace MarkCompleted(ctx) with " +
-			"Migrate(ctx, migrate.WithoutMigrationFunc())")
+			"Migrate(ctx, migrate.WithNopMigration())")
 
-	return m.Migrate(ctx, WithoutMigrationFunc())
+	return m.Migrate(ctx, WithNopMigration())
 }
 
 func (m *Migrator) CreateGo(ctx context.Context, name string) (*MigrationFile, error) {


### PR DESCRIPTION
Updates https://github.com/uptrace/bun/issues/49

This PR
- Adds MarkDone / MarkDone to mark individual migrations
- Adds `Migrations.Sorted` to get the list of all migrations
- Adds new option `WithMigrationDryRun` that can be used with `Migrate` and `Rollback` to mark migrations as done/undone without applying them
- Adds `SelectDoneMigrations` that returns the list of migrations stored in the database
- Adds `SelectLastGroup` that returns the last migration group

@smyrman @Codebreaker101 please review