### PR TITLE
Bump deps version on last bun release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,15 @@ test:
 	done
 
 tag:
+	go mod edit -require github.com/uptrace/bun@v$(VERSION) dialect/pgdialect/go.mod
+	go mod edit -require github.com/uptrace/bun@v$(VERSION) dialect/mysqldialect/go.mod
+	go mod edit -require github.com/uptrace/bun@v$(VERSION) dialect/sqlitedialect/go.mod
+	go mod edit -require github.com/uptrace/bun@v$(VERSION) driver/pgdriver/go.mod
+	go mod edit -require github.com/uptrace/bun@v$(VERSION) dbfixture/go.mod
+	go mod edit -require github.com/uptrace/bun@v$(VERSION) extra/bundebug/go.mod
+	go mod edit -require github.com/uptrace/bun@v$(VERSION) extra/bunotel/go.mod
+	git add \*.mod
+	git commit -m "Bump to version $(VERSION)"
 	git tag $(VERSION)
 	git tag dialect/pgdialect/$(VERSION)
 	git tag dialect/mysqldialect/$(VERSION)


### PR DESCRIPTION
fixes #56 
- Bump the required `bun` version to the one to be released
- Add only .mod files
- Commit before tagging

### To note
Even though this will add only the mod files to the stage, it will commit whatever is on stage. So should there be a check that fails immediately if stage is not empty? Or when committing default to `MESSAGE` if provided so with one commit you add changes and bump the version?

