### PR TITLE
some tiny cleanups to the driver

### DIFF
--- a/driver/pgdriver/config.go
+++ b/driver/pgdriver/config.go
@@ -73,6 +73,9 @@ func WithTLSConfig(cfg *tls.Config) DriverOption {
 }
 
 func WithUser(user string) DriverOption {
+	if user == "" {
+		panic("user is empty")
+	}
 	return func(d *driverConnector) {
 		d.cfg.User = user
 	}
@@ -208,10 +211,7 @@ func env(key, defValue string) string {
 // it can be extended to check other parameters
 func (c *Config) verify() error {
 	if c.User == "" {
-		return errors.New(
-			`pgdriver: username is required. 
-		 	 Check your config and make sure User is not left blank.`,
-		)
+		return errors.New("pgdriver: User option is empty (to configure, use WithUser).")
 	}
 	return nil
 }

--- a/driver/pgdriver/config.go
+++ b/driver/pgdriver/config.go
@@ -202,3 +202,16 @@ func env(key, defValue string) string {
 	}
 	return defValue
 }
+
+// verify is a method to make sure if the config is legitimate
+// in the case it detects any errors, it returns with a non-nil error
+// it can be extended to check other parameters
+func (c *Config) verify() error {
+	if c.User == "" {
+		return errors.New(
+			`pgdriver: username is required. 
+		 	 Check your config and make sure User is not left blank.`,
+		)
+	}
+	return nil
+}


### PR DESCRIPTION
I am trying to make this great driver cleaner. I think we can use a config verifier to check all the configs and enforce some optional security checks such as minimum password length (in the case db is not being managed by dev teams).