### PR TITLE
Add release.sh script

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body: Check CHANGELOG.md for details

--- a/Makefile
+++ b/Makefile
@@ -8,26 +8,6 @@ test:
 	    go vet); \
 	done
 
-tag:
-	go mod edit -require github.com/uptrace/bun@v$(VERSION) dialect/pgdialect/go.mod
-	go mod edit -require github.com/uptrace/bun@v$(VERSION) dialect/mysqldialect/go.mod
-	go mod edit -require github.com/uptrace/bun@v$(VERSION) dialect/sqlitedialect/go.mod
-	go mod edit -require github.com/uptrace/bun@v$(VERSION) driver/pgdriver/go.mod
-	go mod edit -require github.com/uptrace/bun@v$(VERSION) dbfixture/go.mod
-	go mod edit -require github.com/uptrace/bun@v$(VERSION) extra/bundebug/go.mod
-	go mod edit -require github.com/uptrace/bun@v$(VERSION) extra/bunotel/go.mod
-	git add \*.mod
-	git commit -m "Bump to version $(VERSION)"
-	git tag $(VERSION)
-	git tag dialect/pgdialect/$(VERSION)
-	git tag dialect/mysqldialect/$(VERSION)
-	git tag dialect/sqlitedialect/$(VERSION)
-	git tag driver/pgdriver/$(VERSION)
-	git tag driver/sqliteshim/$(VERSION)
-	git tag dbfixture/$(VERSION)
-	git tag extra/bundebug/$(VERSION)
-	git tag extra/bunotel/$(VERSION)
-
 go_mod_tidy:
 	set -e; for dir in $(ALL_GO_MOD_DIRS); do \
 	  echo "go mod tidy in $${dir}"; \

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,21 @@
+# Releasing
+
+1. Run `release.sh` script which updates versions in go.mod files and pushes a new branch to GitHub:
+
+```shell
+./scripts/release.sh -t v1.0.0
+```
+
+2. Open a pull request and wait for the build to finish.
+
+3. Merge the pull request and run `tag.sh` to create tags for packages:
+
+```shell
+./scripts/tag.sh -t v1.0.0
+```
+
+4. Push the tags:
+
+```shell
+git push origin --tags
+```

--- a/example/basic/go.mod
+++ b/example/basic/go.mod
@@ -10,6 +10,8 @@ replace github.com/uptrace/bun/extra/bundebug => ../../extra/bundebug
 
 replace github.com/uptrace/bun/dialect/sqlitedialect => ../../dialect/sqlitedialect
 
+replace github.com/uptrace/bun/driver/sqliteshim => ../../driver/sqliteshim
+
 require (
 	github.com/uptrace/bun v0.1.1
 	github.com/uptrace/bun/dbfixture v0.0.0-00010101000000-000000000000

--- a/example/belongs-to/go.mod
+++ b/example/belongs-to/go.mod
@@ -8,6 +8,8 @@ replace github.com/uptrace/bun/extra/bundebug => ../../extra/bundebug
 
 replace github.com/uptrace/bun/dialect/sqlitedialect => ../../dialect/sqlitedialect
 
+replace github.com/uptrace/bun/driver/sqliteshim => ../../driver/sqliteshim
+
 require (
 	github.com/uptrace/bun v0.1.1
 	github.com/uptrace/bun/dialect/sqlitedialect v0.0.0-20210507070510-0d95488a5553

--- a/example/create-table-index/go.mod
+++ b/example/create-table-index/go.mod
@@ -8,6 +8,8 @@ replace github.com/uptrace/bun/extra/bundebug => ../../extra/bundebug
 
 replace github.com/uptrace/bun/dialect/sqlitedialect => ../../dialect/sqlitedialect
 
+replace github.com/uptrace/bun/driver/sqliteshim => ../../driver/sqliteshim
+
 require (
 	github.com/uptrace/bun v0.1.1
 	github.com/uptrace/bun/dialect/sqlitedialect v0.0.0-00010101000000-000000000000

--- a/example/fixture/go.mod
+++ b/example/fixture/go.mod
@@ -8,6 +8,8 @@ replace github.com/uptrace/bun/extra/bundebug => ../../extra/bundebug
 
 replace github.com/uptrace/bun/dialect/sqlitedialect => ../../dialect/sqlitedialect
 
+replace github.com/uptrace/bun/driver/sqliteshim => ../../driver/sqliteshim
+
 replace github.com/uptrace/bun/dbfixture => ../../dbfixture
 
 require (

--- a/example/has-many/go.mod
+++ b/example/has-many/go.mod
@@ -8,6 +8,8 @@ replace github.com/uptrace/bun/extra/bundebug => ../../extra/bundebug
 
 replace github.com/uptrace/bun/dialect/sqlitedialect => ../../dialect/sqlitedialect
 
+replace github.com/uptrace/bun/driver/sqliteshim => ../../driver/sqliteshim
+
 require (
 	github.com/uptrace/bun v0.1.1
 	github.com/uptrace/bun/dialect/sqlitedialect v0.0.0-20210507070510-0d95488a5553

--- a/example/has-one/go.mod
+++ b/example/has-one/go.mod
@@ -8,6 +8,8 @@ replace github.com/uptrace/bun/extra/bundebug => ../../extra/bundebug
 
 replace github.com/uptrace/bun/dialect/sqlitedialect => ../../dialect/sqlitedialect
 
+replace github.com/uptrace/bun/driver/sqliteshim => ../../driver/sqliteshim
+
 require (
 	github.com/uptrace/bun v0.1.1
 	github.com/uptrace/bun/dialect/sqlitedialect v0.0.0-20210507070510-0d95488a5553

--- a/example/many-to-many/go.mod
+++ b/example/many-to-many/go.mod
@@ -8,6 +8,8 @@ replace github.com/uptrace/bun/extra/bundebug => ../../extra/bundebug
 
 replace github.com/uptrace/bun/dialect/sqlitedialect => ../../dialect/sqlitedialect
 
+replace github.com/uptrace/bun/driver/sqliteshim => ../../driver/sqliteshim
+
 require (
 	github.com/uptrace/bun v0.1.1
 	github.com/uptrace/bun/dialect/sqlitedialect v0.0.0-20210507070510-0d95488a5553

--- a/example/migrate/go.mod
+++ b/example/migrate/go.mod
@@ -8,6 +8,8 @@ replace github.com/uptrace/bun/extra/bundebug => ../../extra/bundebug
 
 replace github.com/uptrace/bun/dialect/sqlitedialect => ../../dialect/sqlitedialect
 
+replace github.com/uptrace/bun/driver/sqliteshim => ../../driver/sqliteshim
+
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/example/model-hooks/go.mod
+++ b/example/model-hooks/go.mod
@@ -10,6 +10,8 @@ replace github.com/uptrace/bun/extra/bundebug => ../../extra/bundebug
 
 replace github.com/uptrace/bun/dialect/sqlitedialect => ../../dialect/sqlitedialect
 
+replace github.com/uptrace/bun/driver/sqliteshim => ../../driver/sqliteshim
+
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/uptrace/bun v0.1.1

--- a/example/tx-composition/go.mod
+++ b/example/tx-composition/go.mod
@@ -10,6 +10,8 @@ replace github.com/uptrace/bun/extra/bundebug => ../../extra/bundebug
 
 replace github.com/uptrace/bun/dialect/sqlitedialect => ../../dialect/sqlitedialect
 
+replace github.com/uptrace/bun/driver/sqliteshim => ../../driver/sqliteshim
+
 require (
 	github.com/uptrace/bun v0.1.1
 	github.com/uptrace/bun/dialect/sqlitedialect v0.0.0-20210507070510-0d95488a5553

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -e
+
+help() {
+    cat <<- EOF
+Usage: TAG=tag $0
+
+Updates version in go.mod files and pushes a new brash to GitHub.
+
+VARIABLES:
+  TAG        git tag, for example, v1.0.0
+EOF
+    exit 0
+}
+
+if [ -z "$TAG" ]
+then
+    printf "TAG is required\n\n"
+    help
+fi
+
+TAG_REGEX="^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(\\-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+if ! [[ "${TAG}" =~ ${TAG_REGEX} ]]; then
+    printf "TAG is not valid: ${TAG}\n\n"
+    exit 1
+fi
+
+TAG_FOUND=`git tag --list ${TAG}`
+if [[ ${TAG_FOUND} = ${TAG} ]] ; then
+    printf "tag ${TAG} already exists\n\n"
+    exit 1
+fi
+
+if ! git diff --quiet
+then
+    printf "working tree is not clean\n\n"
+    git status
+    exit 1
+fi
+
+git checkout master
+
+PACKAGE_DIRS=$(find . -mindepth 2 -type f -name 'go.mod' -exec dirname {} \; \
+  | sed 's/^\.\///' \
+  | sort)
+
+for dir in $PACKAGE_DIRS
+do
+    sed --in-place \
+      "s/uptrace\/bun\([^ ]*\) v.*/uptrace\/bun\1 ${TAG}/" "${dir}/go.mod"
+done
+
+for dir in $PACKAGE_DIRS
+do
+    printf "${dir}: go mod tidy\n"
+    (cd ./${dir} && go mod tidy)
+done
+
+sed --in-place "s/\(return \)\"[^\"]*\"/\1\"${TAG#v}\"/" ./version.go
+
+git checkout -b release/${TAG} master
+git add -u
+git commit -m "Release $TAG"
+git push origin release/${TAG}

--- a/scripts/tag.sh
+++ b/scripts/tag.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -e
+
+help() {
+    cat <<- EOF
+Usage: TAG=tag $0
+
+Creates git tags for public Go packages.
+
+VARIABLES:
+  TAG        git tag, for example, v1.0.0
+EOF
+    exit 0
+}
+
+if [ -z "$TAG" ]
+then
+    printf "TAG env var is required\n\n";
+    help
+fi
+
+if ! grep -Fq "\"${TAG#v}\"" version.go
+then
+    printf "version.go does not contain ${TAG#v}\n"
+    exit 1
+fi
+
+PACKAGE_DIRS=$(find . -mindepth 2 -type f -name 'go.mod' -exec dirname {} \; \
+  | grep -E -v "example|internal" \
+  | sed 's/^\.\///' \
+  | sort)
+
+git tag ${TAG}
+
+for dir in $PACKAGE_DIRS
+do
+    printf "tagging ${dir}/${TAG}\n"
+    git tag ${dir}/${TAG}
+done

--- a/version.go
+++ b/version.go
@@ -1,0 +1,6 @@
+package bun
+
+// Version is the current release version.
+func Version() string {
+	return "0.0.1"
+}


### PR DESCRIPTION
Fixes https://github.com/uptrace/bun/issues/56

@monkey92t @Codebreaker101 please take a look and let me know what do you think (RELEASING.md should have a brief outline). I plan to use the same script to release go-redis as well.

As the next step we can add https://github.com/softprops/action-gh-release to automatically make a GitHub release.