### PR TITLE
Remove go-pg reference from package README

### DIFF
--- a/buntypes/bigint/README.md
+++ b/buntypes/bigint/README.md
@@ -5,8 +5,6 @@ Disclaimer: math/big does not implement database/sql scan/value methods and it c
 
 ## Example use with bun
 
-**go-pg** is an amazing orm for gophers to utilize postgres. This package is used to help **go-pg** users implement **math/big** functionalities.
-
 ```
 
 	type TableWithBigint struct {


### PR DESCRIPTION
Just happened to notice it in #113 