### PR TITLE
Mysql compatibility fixes

### DIFF
--- a/dialect/append.go
+++ b/dialect/append.go
@@ -82,7 +82,7 @@ func AppendBytes(b []byte, bs []byte) []byte {
 		return AppendNull(b)
 	}
 
-	b = append(b, `'\x`...)
+	b = append(b, `X'`...)
 
 	s := len(b)
 	b = append(b, make([]byte, hex.EncodedLen(len(bs)))...)


### PR DESCRIPTION
MySQL uses `On("DUPLICATE KEY UPDATE")` vs PostgreSQL's `On("CONFLICT DO UPDATE")` and also has a slightly different format for `VALUES`. 

I also included an example of a change I needed to make to support binary data in MySQL. I understand this change cannot be merged as-is and I would appreciate some guidance on how to make it correctly.