### PR TITLE
fix: Fixed bug creating table when model has no columns.

### DIFF
--- a/internal/dbtest/query_test.go
+++ b/internal/dbtest/query_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/bradleyjkemp/cupaloy"
+	"github.com/stretchr/testify/assert"
+	"github.com/uptrace/bun/dialect"
 
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/schema"
@@ -643,5 +645,50 @@ func TestQuery(t *testing.T) {
 				}
 			})
 		}
+	})
+}
+
+func TestCreateTableQuery_AppendQuery(t *testing.T) {
+	testEachDB(t, func(t *testing.T, dbName string, db *bun.DB) {
+		t.Run("with columns from model", func(t *testing.T) {
+			type Login struct {
+				Email    string
+				Password string
+			}
+
+			output, err := bun.NewCreateTableQuery(db).
+				Model(&Login{}).
+				AppendQuery(schema.NewFormatter(db.Dialect()), nil)
+			assert.NoError(t, err, "should be able to generate a simple create table query without error")
+			assert.NotEmpty(t, output, "the resulting query byte array should not be empty")
+			switch db.Dialect().Name() {
+			case dialect.PG, dialect.SQLite:
+				assert.Equal(t, `CREATE TABLE "logins" ("email" VARCHAR, "password" VARCHAR)`, string(output))
+			case dialect.MySQL:
+				assert.Equal(t, "CREATE TABLE `logins` (`email` VARCHAR(255), `password` VARCHAR(255))", string(output))
+			default:
+				t.Fatalf("unknown dialect: %+v", db.Dialect().Name())
+			}
+		})
+
+		t.Run("with columns from column expr", func(t *testing.T) {
+			type Login struct{}
+
+			output, err := bun.NewCreateTableQuery(db).
+				Model(&Login{}).
+				ColumnExpr(`email VARCHAR`).
+				ColumnExpr(`password VARCHAR`).
+				AppendQuery(schema.NewFormatter(db.Dialect()), nil)
+			assert.NoError(t, err, "should be able to generate a simple create table query without error")
+			assert.NotEmpty(t, output, "the resulting query byte array should not be empty")
+			switch db.Dialect().Name() {
+			case dialect.PG, dialect.SQLite:
+				assert.Equal(t, `CREATE TABLE "logins" (email VARCHAR, password VARCHAR)`, string(output))
+			case dialect.MySQL:
+				assert.Equal(t, "CREATE TABLE `logins` (email VARCHAR, password VARCHAR)", string(output))
+			default:
+				t.Fatalf("unknown dialect: %+v", db.Dialect().Name())
+			}
+		})
 	})
 }


### PR DESCRIPTION
If you wanted to create a table using only the ColumnExpr function and not provide columns from the struct model. Then you would receive syntax errors as the ColumnExpr columns always have a `,` prepended before them even if no columns were appended before them. This makes sure that the `,` is properly prepended before adding columns from the ColumnExpr. It also evaluates the AUTO_INCREMENT feature from the provided formatter dialect rather than the DB. This will make testing the AppendQuery method easier in the future as the library evolves as it this method is now _slightly_ less dependent on a DB connection to be called.