### PR TITLE
feat: Add `Dialect()` to Transaction and IDB interface.

### DIFF
--- a/db.go
+++ b/db.go
@@ -473,6 +473,10 @@ func (tx Tx) QueryRowContext(ctx context.Context, query string, args ...interfac
 	return row
 }
 
+func (tx Tx) Dialect() schema.Dialect {
+	return tx.db.Dialect()
+}
+
 //------------------------------------------------------------------------------
 
 func (tx Tx) NewValues(model interface{}) *ValuesQuery {

--- a/query_base.go
+++ b/query_base.go
@@ -43,6 +43,7 @@ var (
 // IDB is a common interface for *bun.DB, bun.Conn, and bun.Tx.
 type IDB interface {
 	IConn
+	Dialect() schema.Dialect
 
 	NewValues(model interface{}) *ValuesQuery
 	NewSelect() *SelectQuery


### PR DESCRIPTION
This is just a little addition to better support dialect specific code within transactions or functions that just want an IDB input.