### PR TITLE
feat: use one `IDB` instead of `*DB` with `IConn`

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,0 +1,53 @@
+package bun
+
+import (
+	"context"
+)
+
+type contextKey struct{}
+
+type scope struct {
+	query Query
+	model Model
+	event *QueryEvent
+}
+
+var scopeKey = contextKey{}
+
+func (s *scope) copy() *scope {
+	return &scope{
+		query: s.query,
+		model: s.model,
+		event: s.event,
+	}
+}
+
+func scopeFromContext(ctx context.Context) *scope {
+	state := ctx.Value(scopeKey)
+	if state == nil {
+		return &scope{}
+	}
+	return state.(*scope)
+}
+
+func withQueryScope(ctx context.Context, q Query) context.Context {
+	scopeVal := scopeFromContext(ctx).copy()
+	scopeVal.query = q
+	return context.WithValue(ctx, scopeKey, scopeVal)
+}
+
+func withModel(ctx context.Context, m Model) context.Context {
+	scopeVal := scopeFromContext(ctx).copy()
+	scopeVal.model = m
+	return context.WithValue(ctx, scopeKey, scopeVal)
+}
+
+func withEvent(ctx context.Context, e *QueryEvent) context.Context {
+	scopeVal := scopeFromContext(ctx).copy()
+	scopeVal.event = e
+	return context.WithValue(ctx, scopeKey, scopeVal)
+}
+
+func isManagedQuery(ctx context.Context) bool {
+	return scopeFromContext(ctx).query != nil
+}

--- a/context.go
+++ b/context.go
@@ -43,9 +43,9 @@ func withModel(ctx context.Context, m Model) context.Context {
 }
 
 func withEvent(ctx context.Context, e *QueryEvent) context.Context {
-	scopeVal := scopeFromContext(ctx).copy()
+	scopeVal := scopeFromContext(ctx)
 	scopeVal.event = e
-	return context.WithValue(ctx, scopeKey, scopeVal)
+	return context.WithValue(ctx, scopeKey, scopeVal.copy())
 }
 
 func isManagedQuery(ctx context.Context) bool {

--- a/internal/dbtest/pg_test.go
+++ b/internal/dbtest/pg_test.go
@@ -296,10 +296,10 @@ func TestPGTransaction(t *testing.T) {
 	tx, err := db.BeginTx(ctx, nil)
 	require.NoError(t, err)
 
-	_, err = db.NewCreateTable().Conn(tx).Model((*Model)(nil)).Exec(ctx)
+	_, err = tx.NewCreateTable().Model((*Model)(nil)).Exec(ctx)
 	require.NoError(t, err)
 
-	n, err := db.NewSelect().Conn(tx).Model((*Model)(nil)).Count(ctx)
+	n, err := tx.NewSelect().Model((*Model)(nil)).Count(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 0, n)
 

--- a/migrate/migration.go
+++ b/migrate/migration.go
@@ -73,7 +73,7 @@ func NewSQLMigrationFunc(fsys fs.FS, name string) MigrationFunc {
 			return err
 		}
 
-		var idb bun.IConn
+		var idb bun.IDB
 
 		if isTx {
 			tx, err := db.BeginTx(ctx, nil)

--- a/model.go
+++ b/model.go
@@ -44,7 +44,7 @@ type TableModel interface {
 	updateSoftDeleteField(time.Time) error
 }
 
-func newModel(db *DB, dest []interface{}) (Model, error) {
+func newModel(db IDB, dest []interface{}) (Model, error) {
 	if len(dest) == 1 {
 		return _newModel(db, dest[0], true)
 	}
@@ -68,11 +68,11 @@ func newModel(db *DB, dest []interface{}) (Model, error) {
 	return newSliceModel(db, dest, values), nil
 }
 
-func newSingleModel(db *DB, dest interface{}) (Model, error) {
+func newSingleModel(db IDB, dest interface{}) (Model, error) {
 	return _newModel(db, dest, false)
 }
 
-func _newModel(db *DB, dest interface{}, scan bool) (Model, error) {
+func _newModel(db IDB, dest interface{}, scan bool) (Model, error) {
 	switch dest := dest.(type) {
 	case nil:
 		return nil, errNilModel
@@ -139,7 +139,7 @@ func _newModel(db *DB, dest interface{}, scan bool) (Model, error) {
 }
 
 func newTableModelIndex(
-	db *DB,
+	db IDB,
 	table *schema.Table,
 	root reflect.Value,
 	index []int,

--- a/model_map.go
+++ b/model_map.go
@@ -10,7 +10,7 @@ import (
 )
 
 type mapModel struct {
-	db *DB
+	db IDB
 
 	dest *map[string]interface{}
 	m    map[string]interface{}
@@ -23,7 +23,7 @@ type mapModel struct {
 
 var _ Model = (*mapModel)(nil)
 
-func newMapModel(db *DB, dest *map[string]interface{}) *mapModel {
+func newMapModel(db IDB, dest *map[string]interface{}) *mapModel {
 	m := &mapModel{
 		db:   db,
 		dest: dest,

--- a/model_map_slice.go
+++ b/model_map_slice.go
@@ -19,7 +19,7 @@ type mapSliceModel struct {
 
 var _ Model = (*mapSliceModel)(nil)
 
-func newMapSliceModel(db *DB, dest *[]map[string]interface{}) *mapSliceModel {
+func newMapSliceModel(db IDB, dest *[]map[string]interface{}) *mapSliceModel {
 	return &mapSliceModel{
 		mapModel: mapModel{
 			db: db,
@@ -99,7 +99,7 @@ func (m *mapSliceModel) appendValues(fmter schema.Formatter, b []byte) (_ []byte
 	slice := *m.dest
 
 	b = append(b, "VALUES "...)
-	if m.db.features.Has(feature.ValuesRow) {
+	if m.db.HasFeature(feature.ValuesRow) {
 		b = append(b, "ROW("...)
 	} else {
 		b = append(b, '(')
@@ -118,7 +118,7 @@ func (m *mapSliceModel) appendValues(fmter schema.Formatter, b []byte) (_ []byte
 	for i, el := range slice {
 		if i > 0 {
 			b = append(b, "), "...)
-			if m.db.features.Has(feature.ValuesRow) {
+			if m.db.HasFeature(feature.ValuesRow) {
 				b = append(b, "ROW("...)
 			} else {
 				b = append(b, '(')

--- a/model_scan.go
+++ b/model_scan.go
@@ -9,7 +9,7 @@ import (
 )
 
 type scanModel struct {
-	db *DB
+	db IDB
 
 	dest      []interface{}
 	scanIndex int
@@ -17,7 +17,7 @@ type scanModel struct {
 
 var _ Model = (*scanModel)(nil)
 
-func newScanModel(db *DB, dest []interface{}) *scanModel {
+func newScanModel(db IDB, dest []interface{}) *scanModel {
 	return &scanModel{
 		db:   db,
 		dest: dest,

--- a/model_slice.go
+++ b/model_slice.go
@@ -23,7 +23,7 @@ type sliceModel struct {
 
 var _ Model = (*sliceModel)(nil)
 
-func newSliceModel(db *DB, dest []interface{}, values []reflect.Value) *sliceModel {
+func newSliceModel(db IDB, dest []interface{}, values []reflect.Value) *sliceModel {
 	return &sliceModel{
 		dest:   dest,
 		values: values,

--- a/model_table_slice.go
+++ b/model_table_slice.go
@@ -21,7 +21,7 @@ type sliceTableModel struct {
 var _ TableModel = (*sliceTableModel)(nil)
 
 func newSliceTableModel(
-	db *DB, dest interface{}, slice reflect.Value, elemType reflect.Type,
+	db IDB, dest interface{}, slice reflect.Value, elemType reflect.Type,
 ) *sliceTableModel {
 	m := &sliceTableModel{
 		structTableModel: structTableModel{

--- a/model_table_struct.go
+++ b/model_table_struct.go
@@ -12,7 +12,7 @@ import (
 )
 
 type structTableModel struct {
-	db    *DB
+	db    IDB
 	table *schema.Table
 
 	rel   *schema.Relation
@@ -32,7 +32,7 @@ type structTableModel struct {
 
 var _ TableModel = (*structTableModel)(nil)
 
-func newStructTableModel(db *DB, dest interface{}, table *schema.Table) *structTableModel {
+func newStructTableModel(db IDB, dest interface{}, table *schema.Table) *structTableModel {
 	return &structTableModel{
 		db:    db,
 		table: table,
@@ -40,7 +40,7 @@ func newStructTableModel(db *DB, dest interface{}, table *schema.Table) *structT
 	}
 }
 
-func newStructTableModelValue(db *DB, dest interface{}, v reflect.Value) *structTableModel {
+func newStructTableModelValue(db IDB, dest interface{}, v reflect.Value) *structTableModel {
 	return &structTableModel{
 		db:    db,
 		table: db.Table(v.Type()),
@@ -311,7 +311,7 @@ func (m *structTableModel) ScanColumn(column string, src interface{}) error {
 	if ok, err := m.scanColumn(column, src); ok {
 		return err
 	}
-	if column == "" || column[0] == '_' || m.db.flags.Has(discardUnknownColumns) {
+	if column == "" || column[0] == '_' || m.db._flags().Has(discardUnknownColumns) {
 		return nil
 	}
 	return fmt.Errorf("bun: %s does not have column %q", m.table.TypeName, column)

--- a/query_base.go
+++ b/query_base.go
@@ -114,7 +114,6 @@ func (q *baseQuery) GetTableName() string {
 }
 
 func (q *baseQuery) SetDB(db IDB) {
-	// FIXME: Unwrap Bun wrappers to not call query hooks twice.
 	q.db = db
 }
 

--- a/query_base.go
+++ b/query_base.go
@@ -60,6 +60,12 @@ type IDB interface {
 	)
 }
 
+var (
+	_ IDB = (*DB)(nil)
+	_ IDB = (*Conn)(nil)
+	_ IDB = (*Tx)(nil)
+)
+
 type baseQuery struct {
 	db IDB
 

--- a/query_column_add.go
+++ b/query_column_add.go
@@ -17,18 +17,12 @@ type AddColumnQuery struct {
 
 var _ Query = (*AddColumnQuery)(nil)
 
-func NewAddColumnQuery(db *DB) *AddColumnQuery {
+func NewAddColumnQuery(db IDB) *AddColumnQuery {
 	q := &AddColumnQuery{
 		baseQuery: baseQuery{
-			db:   db,
-			conn: db.DB,
+			db: db,
 		},
 	}
-	return q
-}
-
-func (q *AddColumnQuery) Conn(db IConn) *AddColumnQuery {
-	q.setConn(db)
 	return q
 }
 
@@ -106,7 +100,7 @@ func (q *AddColumnQuery) AppendQuery(fmter schema.Formatter, b []byte) (_ []byte
 //------------------------------------------------------------------------------
 
 func (q *AddColumnQuery) Exec(ctx context.Context, dest ...interface{}) (sql.Result, error) {
-	queryBytes, err := q.AppendQuery(q.db.fmter, q.db.makeQueryBytes())
+	queryBytes, err := q.AppendQuery(q.db.Formatter(), q.db.makeQueryBytes())
 	if err != nil {
 		return nil, err
 	}

--- a/query_column_drop.go
+++ b/query_column_drop.go
@@ -15,18 +15,12 @@ type DropColumnQuery struct {
 
 var _ Query = (*DropColumnQuery)(nil)
 
-func NewDropColumnQuery(db *DB) *DropColumnQuery {
+func NewDropColumnQuery(db IDB) *DropColumnQuery {
 	q := &DropColumnQuery{
 		baseQuery: baseQuery{
-			db:   db,
-			conn: db.DB,
+			db: db,
 		},
 	}
-	return q
-}
-
-func (q *DropColumnQuery) Conn(db IConn) *DropColumnQuery {
-	q.setConn(db)
 	return q
 }
 
@@ -102,7 +96,7 @@ func (q *DropColumnQuery) AppendQuery(fmter schema.Formatter, b []byte) (_ []byt
 //------------------------------------------------------------------------------
 
 func (q *DropColumnQuery) Exec(ctx context.Context, dest ...interface{}) (sql.Result, error) {
-	queryBytes, err := q.AppendQuery(q.db.fmter, q.db.makeQueryBytes())
+	queryBytes, err := q.AppendQuery(q.db.Formatter(), q.db.makeQueryBytes())
 	if err != nil {
 		return nil, err
 	}

--- a/query_delete.go
+++ b/query_delete.go
@@ -17,20 +17,14 @@ type DeleteQuery struct {
 
 var _ Query = (*DeleteQuery)(nil)
 
-func NewDeleteQuery(db *DB) *DeleteQuery {
+func NewDeleteQuery(db IDB) *DeleteQuery {
 	q := &DeleteQuery{
 		whereBaseQuery: whereBaseQuery{
 			baseQuery: baseQuery{
-				db:   db,
-				conn: db.DB,
+				db: db,
 			},
 		},
 	}
-	return q
-}
-
-func (q *DeleteQuery) Conn(db IConn) *DeleteQuery {
-	q.setConn(db)
 	return q
 }
 
@@ -123,7 +117,7 @@ func (q *DeleteQuery) Returning(query string, args ...interface{}) *DeleteQuery 
 }
 
 func (q *DeleteQuery) hasReturning() bool {
-	if !q.db.features.Has(feature.Returning) {
+	if !q.db.HasFeature(feature.Returning) {
 		return false
 	}
 	return q.returningQuery.hasReturning()
@@ -159,7 +153,7 @@ func (q *DeleteQuery) AppendQuery(fmter schema.Formatter, b []byte) (_ []byte, e
 	}
 
 	q = q.WhereDeleted()
-	withAlias := q.db.features.Has(feature.DeleteTableAlias)
+	withAlias := q.db.HasFeature(feature.DeleteTableAlias)
 
 	b, err = q.appendWith(fmter, b)
 	if err != nil {
@@ -233,7 +227,7 @@ func (q *DeleteQuery) Exec(ctx context.Context, dest ...interface{}) (sql.Result
 		return nil, err
 	}
 
-	queryBytes, err := q.AppendQuery(q.db.fmter, q.db.makeQueryBytes())
+	queryBytes, err := q.AppendQuery(q.db.Formatter(), q.db.makeQueryBytes())
 	if err != nil {
 		return nil, err
 	}

--- a/query_index_create.go
+++ b/query_index_create.go
@@ -24,20 +24,14 @@ type CreateIndexQuery struct {
 
 var _ Query = (*CreateIndexQuery)(nil)
 
-func NewCreateIndexQuery(db *DB) *CreateIndexQuery {
+func NewCreateIndexQuery(db IDB) *CreateIndexQuery {
 	q := &CreateIndexQuery{
 		whereBaseQuery: whereBaseQuery{
 			baseQuery: baseQuery{
-				db:   db,
-				conn: db.DB,
+				db: db,
 			},
 		},
 	}
-	return q
-}
-
-func (q *CreateIndexQuery) Conn(db IConn) *CreateIndexQuery {
-	q.setConn(db)
 	return q
 }
 
@@ -232,7 +226,7 @@ func (q *CreateIndexQuery) AppendQuery(fmter schema.Formatter, b []byte) (_ []by
 //------------------------------------------------------------------------------
 
 func (q *CreateIndexQuery) Exec(ctx context.Context, dest ...interface{}) (sql.Result, error) {
-	queryBytes, err := q.AppendQuery(q.db.fmter, q.db.makeQueryBytes())
+	queryBytes, err := q.AppendQuery(q.db.Formatter(), q.db.makeQueryBytes())
 	if err != nil {
 		return nil, err
 	}

--- a/query_index_drop.go
+++ b/query_index_drop.go
@@ -20,18 +20,12 @@ type DropIndexQuery struct {
 
 var _ Query = (*DropIndexQuery)(nil)
 
-func NewDropIndexQuery(db *DB) *DropIndexQuery {
+func NewDropIndexQuery(db IDB) *DropIndexQuery {
 	q := &DropIndexQuery{
 		baseQuery: baseQuery{
-			db:   db,
-			conn: db.DB,
+			db: db,
 		},
 	}
-	return q
-}
-
-func (q *DropIndexQuery) Conn(db IConn) *DropIndexQuery {
-	q.setConn(db)
 	return q
 }
 
@@ -100,7 +94,7 @@ func (q *DropIndexQuery) AppendQuery(fmter schema.Formatter, b []byte) (_ []byte
 //------------------------------------------------------------------------------
 
 func (q *DropIndexQuery) Exec(ctx context.Context, dest ...interface{}) (sql.Result, error) {
-	queryBytes, err := q.AppendQuery(q.db.fmter, q.db.makeQueryBytes())
+	queryBytes, err := q.AppendQuery(q.db.Formatter(), q.db.makeQueryBytes())
 	if err != nil {
 		return nil, err
 	}

--- a/query_select.go
+++ b/query_select.go
@@ -769,12 +769,14 @@ func (q *SelectQuery) Count(ctx context.Context) (int, error) {
 	}
 
 	query := internal.String(queryBytes)
-	ctx, event := q.db.beforeQuery(ctx, qq, query, nil, q.model)
+
+	ctx = withQueryScope(ctx, qq)
+	ctx = withModel(ctx, q.model)
 
 	var num int
 	err = q.db.QueryRowContext(ctx, query).Scan(&num)
 
-	q.db.afterQuery(ctx, event, nil, err)
+	q.db.afterQuery(ctx, nil, err)
 
 	return num, err
 }
@@ -854,12 +856,14 @@ func (q *SelectQuery) Exists(ctx context.Context) (bool, error) {
 	}
 
 	query := internal.String(queryBytes)
-	ctx, event := q.db.beforeQuery(ctx, qq, query, nil, q.model)
+
+	ctx = withQueryScope(ctx, qq)
+	ctx = withModel(ctx, q.model)
 
 	var exists bool
 	err = q.db.QueryRowContext(ctx, query).Scan(&exists)
 
-	q.db.afterQuery(ctx, event, nil, err)
+	q.db.afterQuery(ctx, nil, err)
 
 	return exists, err
 }

--- a/query_select.go
+++ b/query_select.go
@@ -338,10 +338,8 @@ func (q *SelectQuery) selectJoins(ctx context.Context, joins []relationJoin) err
 		case schema.HasOneRelation, schema.BelongsToRelation:
 			err = q.selectJoins(ctx, j.JoinModel.getJoins())
 		case schema.HasManyRelation:
-			// FIXME: calling q.db.NewSelect assumes we're not in a transaction
 			err = j.selectMany(ctx, q.db.NewSelect())
 		case schema.ManyToManyRelation:
-			// FIXME: calling q.db.NewSelect assumes we're not in a transaction
 			err = j.selectM2M(ctx, q.db.NewSelect())
 		default:
 			panic("not reached")

--- a/query_table_create.go
+++ b/query_table_create.go
@@ -26,18 +26,12 @@ type CreateTableQuery struct {
 
 var _ Query = (*CreateTableQuery)(nil)
 
-func NewCreateTableQuery(db *DB) *CreateTableQuery {
+func NewCreateTableQuery(db IDB) *CreateTableQuery {
 	q := &CreateTableQuery{
 		baseQuery: baseQuery{
-			db:   db,
-			conn: db.DB,
+			db: db,
 		},
 	}
-	return q
-}
-
-func (q *CreateTableQuery) Conn(db IConn) *CreateTableQuery {
-	q.setConn(db)
 	return q
 }
 
@@ -276,7 +270,7 @@ func (q *CreateTableQuery) Exec(ctx context.Context, dest ...interface{}) (sql.R
 		return nil, err
 	}
 
-	queryBytes, err := q.AppendQuery(q.db.fmter, q.db.makeQueryBytes())
+	queryBytes, err := q.AppendQuery(q.db.Formatter(), q.db.makeQueryBytes())
 	if err != nil {
 		return nil, err
 	}

--- a/query_table_drop.go
+++ b/query_table_drop.go
@@ -17,18 +17,12 @@ type DropTableQuery struct {
 
 var _ Query = (*DropTableQuery)(nil)
 
-func NewDropTableQuery(db *DB) *DropTableQuery {
+func NewDropTableQuery(db IDB) *DropTableQuery {
 	q := &DropTableQuery{
 		baseQuery: baseQuery{
-			db:   db,
-			conn: db.DB,
+			db: db,
 		},
 	}
-	return q
-}
-
-func (q *DropTableQuery) Conn(db IConn) *DropTableQuery {
-	q.setConn(db)
 	return q
 }
 
@@ -108,7 +102,7 @@ func (q *DropTableQuery) Exec(ctx context.Context, dest ...interface{}) (sql.Res
 		}
 	}
 
-	queryBytes, err := q.AppendQuery(q.db.fmter, q.db.makeQueryBytes())
+	queryBytes, err := q.AppendQuery(q.db.Formatter(), q.db.makeQueryBytes())
 	if err != nil {
 		return nil, err
 	}

--- a/query_table_truncate.go
+++ b/query_table_truncate.go
@@ -18,18 +18,12 @@ type TruncateTableQuery struct {
 
 var _ Query = (*TruncateTableQuery)(nil)
 
-func NewTruncateTableQuery(db *DB) *TruncateTableQuery {
+func NewTruncateTableQuery(db IDB) *TruncateTableQuery {
 	q := &TruncateTableQuery{
 		baseQuery: baseQuery{
-			db:   db,
-			conn: db.DB,
+			db: db,
 		},
 	}
-	return q
-}
-
-func (q *TruncateTableQuery) Conn(db IConn) *TruncateTableQuery {
-	q.setConn(db)
 	return q
 }
 
@@ -100,7 +94,7 @@ func (q *TruncateTableQuery) AppendQuery(
 		return nil, err
 	}
 
-	if q.db.features.Has(feature.TableIdentity) {
+	if q.db.HasFeature(feature.TableIdentity) {
 		if q.continueIdentity {
 			b = append(b, " CONTINUE IDENTITY"...)
 		} else {
@@ -116,7 +110,7 @@ func (q *TruncateTableQuery) AppendQuery(
 //------------------------------------------------------------------------------
 
 func (q *TruncateTableQuery) Exec(ctx context.Context, dest ...interface{}) (sql.Result, error) {
-	queryBytes, err := q.AppendQuery(q.db.fmter, q.db.makeQueryBytes())
+	queryBytes, err := q.AppendQuery(q.db.Formatter(), q.db.makeQueryBytes())
 	if err != nil {
 		return nil, err
 	}

--- a/query_update.go
+++ b/query_update.go
@@ -22,20 +22,14 @@ type UpdateQuery struct {
 
 var _ Query = (*UpdateQuery)(nil)
 
-func NewUpdateQuery(db *DB) *UpdateQuery {
+func NewUpdateQuery(db IDB) *UpdateQuery {
 	q := &UpdateQuery{
 		whereBaseQuery: whereBaseQuery{
 			baseQuery: baseQuery{
-				db:   db,
-				conn: db.DB,
+				db: db,
 			},
 		},
 	}
-	return q
-}
-
-func (q *UpdateQuery) Conn(db IConn) *UpdateQuery {
-	q.setConn(db)
 	return q
 }
 
@@ -159,7 +153,7 @@ func (q *UpdateQuery) Returning(query string, args ...interface{}) *UpdateQuery 
 }
 
 func (q *UpdateQuery) hasReturning() bool {
-	if !q.db.features.Has(feature.Returning) {
+	if !q.db.HasFeature(feature.Returning) {
 		return false
 	}
 	return q.returningQuery.hasReturning()
@@ -331,7 +325,7 @@ func (q *UpdateQuery) Bulk() *UpdateQuery {
 		return q
 	}
 
-	set, err := q.updateSliceSet(q.db.fmter, model)
+	set, err := q.updateSliceSet(q.db.Formatter(), model)
 	if err != nil {
 		q.setErr(err)
 		return q
@@ -403,7 +397,7 @@ func (q *UpdateQuery) Exec(ctx context.Context, dest ...interface{}) (sql.Result
 		return nil, err
 	}
 
-	queryBytes, err := q.AppendQuery(q.db.fmter, q.db.makeQueryBytes())
+	queryBytes, err := q.AppendQuery(q.db.Formatter(), q.db.makeQueryBytes())
 	if err != nil {
 		return nil, err
 	}

--- a/query_values.go
+++ b/query_values.go
@@ -21,19 +21,13 @@ var (
 	_ schema.NamedArgAppender = (*ValuesQuery)(nil)
 )
 
-func NewValuesQuery(db *DB, model interface{}) *ValuesQuery {
+func NewValuesQuery(db IDB, model interface{}) *ValuesQuery {
 	q := &ValuesQuery{
 		baseQuery: baseQuery{
-			db:   db,
-			conn: db.DB,
+			db: db,
 		},
 	}
 	q.setTableModel(model)
-	return q
-}
-
-func (q *ValuesQuery) Conn(db IConn) *ValuesQuery {
-	q.setConn(db)
 	return q
 }
 
@@ -133,7 +127,7 @@ func (q *ValuesQuery) appendQuery(
 	fields []*schema.Field,
 ) (_ []byte, err error) {
 	b = append(b, "VALUES "...)
-	if q.db.features.Has(feature.ValuesRow) {
+	if q.db.HasFeature(feature.ValuesRow) {
 		b = append(b, "ROW("...)
 	} else {
 		b = append(b, '(')
@@ -156,7 +150,7 @@ func (q *ValuesQuery) appendQuery(
 		for i := 0; i < sliceLen; i++ {
 			if i > 0 {
 				b = append(b, "), "...)
-				if q.db.features.Has(feature.ValuesRow) {
+				if q.db.HasFeature(feature.ValuesRow) {
 					b = append(b, "ROW("...)
 				} else {
 					b = append(b, '(')

--- a/relation_join.go
+++ b/relation_join.go
@@ -108,7 +108,7 @@ func (j *relationJoin) hasManyColumns(q *SelectQuery) *SelectQuery {
 			}
 
 			var err error
-			b, err = col.AppendQuery(q.db.fmter, b)
+			b, err = col.AppendQuery(q.db.Formatter(), b)
 			if err != nil {
 				q.setErr(err)
 				return q
@@ -133,7 +133,7 @@ func (j *relationJoin) selectM2M(ctx context.Context, q *SelectQuery) error {
 }
 
 func (j *relationJoin) m2mQuery(q *SelectQuery) *SelectQuery {
-	fmter := q.db.fmter
+	fmter := q.db.Formatter()
 
 	m2mModel := newM2MModel(j)
 	if m2mModel == nil {


### PR DESCRIPTION
Fixes #364 

Instead of holding a `*DB` and an `IConn` in each Query struct, we can have `DB`, `Conn`, and `Tx` all implement `IDB` and embed `*DB` so that its methods are promoted to `Conn` and `Tx` by default. This allows query logic to ignore whether the current `IDB` is a transaction or not.

This approach also has the advantage of preventing issues like #364 (which is fixed by this PR) by encapsulating the type of connection.

## Context and Hooks

(This part is subject to change. I might be able to refactor it out.)

Unifying `*DB` and `IConn` changes which hooks are invoked and when. To fix this issue I've added a `scopeContext` that can carry the `Query`, `Model`, and `*QueryEvent` associated with the current Context. This allows us to remove many of the hook invocations since we can dynamically check the `scopeContext` from `IDB` implementations to decide whether or not to invoke hooks, so that before and after hooks are called exactly one time per query.