### PR TITLE
fix: reuse tx for relation join

### DIFF
--- a/query_base.go
+++ b/query_base.go
@@ -86,26 +86,6 @@ func (q *baseQuery) DB() *DB {
 	return q.db
 }
 
-func (q *baseQuery) getTx(ctx context.Context) (Tx, bool) {
-	tx, ok := q.conn.(*sql.Tx)
-	if !ok {
-		return Tx{}, false
-	}
-	return Tx{
-		ctx: ctx,
-		db:  q.db,
-		Tx:  tx,
-	}, true
-}
-
-func (q *baseQuery) idb(ctx context.Context) IDB {
-	tx, ok := q.getTx(ctx)
-	if ok {
-		return tx
-	}
-	return q.db
-}
-
 func (q *baseQuery) GetModel() Model {
 	return q.model
 }

--- a/query_select.go
+++ b/query_select.go
@@ -344,9 +344,9 @@ func (q *SelectQuery) selectJoins(ctx context.Context, joins []relationJoin) err
 		case schema.HasOneRelation, schema.BelongsToRelation:
 			err = q.selectJoins(ctx, j.JoinModel.getJoins())
 		case schema.HasManyRelation:
-			err = j.selectMany(ctx, q.db.NewSelect())
+			err = j.selectMany(ctx, q.idb(ctx).NewSelect())
 		case schema.ManyToManyRelation:
-			err = j.selectM2M(ctx, q.db.NewSelect())
+			err = j.selectM2M(ctx, q.idb(ctx).NewSelect())
 		default:
 			panic("not reached")
 		}

--- a/query_select.go
+++ b/query_select.go
@@ -344,9 +344,9 @@ func (q *SelectQuery) selectJoins(ctx context.Context, joins []relationJoin) err
 		case schema.HasOneRelation, schema.BelongsToRelation:
 			err = q.selectJoins(ctx, j.JoinModel.getJoins())
 		case schema.HasManyRelation:
-			err = j.selectMany(ctx, q.idb(ctx).NewSelect())
+			err = j.selectMany(ctx, q.db.NewSelect().Conn(q.conn))
 		case schema.ManyToManyRelation:
-			err = j.selectM2M(ctx, q.idb(ctx).NewSelect())
+			err = j.selectM2M(ctx, q.db.NewSelect().Conn(q.conn))
 		default:
 			panic("not reached")
 		}


### PR DESCRIPTION
Fixes #364

- Minimal change for reusing an existing transaction when joining relations.
- (Minor) Fixes `IDB`/`IConn` interface checking and comments.