### PR TITLE
feat: add anonymous fields with type name

### DIFF
--- a/internal/dbtest/db_test.go
+++ b/internal/dbtest/db_test.go
@@ -1087,3 +1087,26 @@ func testEmbedModelPointer(t *testing.T, db *bun.DB) {
 	require.NoError(t, err)
 	require.Equal(t, *m1, m2)
 }
+
+func testEmbedTypeField(t *testing.T, db *bun.DB) {
+	type Embed string
+	type Model struct {
+		Embed
+	}
+
+	ctx := context.Background()
+
+	err := db.ResetModel(ctx, (*Model)(nil))
+	require.NoError(t, err)
+
+	m1 := &Model{
+		Embed: Embed("foo"),
+	}
+	_, err = db.NewInsert().Model(m1).Exec(ctx)
+	require.NoError(t, err)
+
+	var m2 Model
+	err = db.NewSelect().Model(&m2).Scan(ctx)
+	require.NoError(t, err)
+	require.Equal(t, *m1, m2)
+}

--- a/internal/dbtest/query_test.go
+++ b/internal/dbtest/query_test.go
@@ -245,7 +245,6 @@ func TestQuery(t *testing.T) {
 		func(db *bun.DB) schema.QueryAppender {
 			return db.NewDropTable().Model(new(Model))
 		},
-
 		func(db *bun.DB) schema.QueryAppender {
 			return db.NewSelect().Model(new(Model)).
 				Where("1").
@@ -649,6 +648,13 @@ func TestQuery(t *testing.T) {
 				Set("str = ?str").
 				Set("time = ?time").
 				WherePK()
+		},
+		func(db *bun.DB) schema.QueryAppender {
+			type ID string
+			type Model struct {
+				ID
+			}
+			return db.NewInsert().Model(&Model{ID: ID("embed")})
 		},
 	}
 

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql5-105
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql5-105
@@ -1,0 +1,1 @@
+INSERT INTO `models` (`id`) VALUES ('embed')

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql8-105
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql8-105
@@ -1,0 +1,1 @@
+INSERT INTO `models` (`id`) VALUES ('embed')

--- a/internal/dbtest/testdata/snapshots/TestQuery-pg-105
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pg-105
@@ -1,0 +1,1 @@
+INSERT INTO "models" ("id") VALUES ('embed')

--- a/internal/dbtest/testdata/snapshots/TestQuery-pgx-105
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pgx-105
@@ -1,0 +1,1 @@
+INSERT INTO "models" ("id") VALUES ('embed')

--- a/internal/dbtest/testdata/snapshots/TestQuery-sqlite-105
+++ b/internal/dbtest/testdata/snapshots/TestQuery-sqlite-105
@@ -1,0 +1,1 @@
+INSERT INTO "models" ("id") VALUES ('embed')

--- a/schema/table.go
+++ b/schema/table.go
@@ -250,6 +250,7 @@ func (t *Table) addFields(typ reflect.Type, prefix string, index []int) {
 				continue
 			}
 
+			// If field is an embedded struct, add each field of the embedded struct.
 			fieldType := indirectType(f.Type)
 			if fieldType.Kind() == reflect.Struct {
 				t.addFields(fieldType, "", withIndex(index, f.Index))
@@ -268,6 +269,8 @@ func (t *Table) addFields(typ reflect.Type, prefix string, index []int) {
 			}
 		}
 
+		// If field is not a struct, add it.
+		// This will also add any embedded non-struct type as a field.
 		if field := t.newField(f, prefix, index); field != nil {
 			t.addField(field)
 		}


### PR DESCRIPTION
Enables support for anonymous fields with non-struct types.

### Example

```go
type MyString string

type A struct{
    MyString // Will create a field called `my_string` with VARCHAR/TEXT type
}
```