### PR TITLE
fix: unique module name for opentelemetry example

### DIFF
--- a/example/opentelemetry/go.mod
+++ b/example/opentelemetry/go.mod
@@ -1,4 +1,4 @@
-module github.com/uptrace/bun/example/basic
+module github.com/uptrace/bun/example/opentelemetry
 
 go 1.16
 


### PR DESCRIPTION
Update the opentelemetry example so that it has a unique module name. Currently this example has the same name as the basic example (`github.com/uptrace/bun/example/basic`) which creates a namespace collision and may break some tools, such as `gopls` in experimental module mode.