### PR TITLE
feat: add baseQuery.GetConn()

### DIFF
--- a/query_base.go
+++ b/query_base.go
@@ -87,6 +87,10 @@ func (q *baseQuery) DB() *DB {
 	return q.db
 }
 
+func (q *baseQuery) GetConn() IConn {
+	return q.conn
+}
+
 func (q *baseQuery) GetModel() Model {
 	return q.model
 }


### PR DESCRIPTION
Allow the user to retrieve the `IConn` from a query so that they can reuse transactions in nested queries.

### Example

```go
q.WhereGroup(sep, func(sq *bun.SelectQuery) *bun.SelectQuery {
	q1 := sq.DB().NewSelect().
		Conn(sq.GetConn()). // <-- reuse Conn from parent query because it might be a Tx
		ColumnExpr("COUNT(*) > 0").
		Model((*Activity)(nil)).
		Join("JOIN assignments AS as").
		JoinOn("as.activity_id = activities.id AND as.resource_id = ?", string(u))
	return sq.Where("(?)", q1)
})
```