### PR TITLE
Add IndexHash to dialect feature flags

### DIFF
--- a/dialect/feature/feature.go
+++ b/dialect/feature/feature.go
@@ -21,4 +21,5 @@ const (
 	InsertOnConflict     // INSERT ... ON CONFLICT
 	InsertOnDuplicateKey // INSERT ... ON DUPLICATE KEY
 	InsertIgnore         // INSERT IGNORE ...
+	IndexHash
 )

--- a/dialect/mysqldialect/dialect.go
+++ b/dialect/mysqldialect/dialect.go
@@ -34,7 +34,8 @@ func New() *Dialect {
 		feature.ValuesRow |
 		feature.TableTruncate |
 		feature.InsertIgnore |
-		feature.InsertOnDuplicateKey
+		feature.InsertOnDuplicateKey |
+		feature.IndexHash
 	return d
 }
 

--- a/dialect/pgdialect/dialect.go
+++ b/dialect/pgdialect/dialect.go
@@ -33,7 +33,8 @@ func New() *Dialect {
 		feature.TableCascade |
 		feature.TableIdentity |
 		feature.TableTruncate |
-		feature.InsertOnConflict
+		feature.InsertOnConflict |
+		feature.IndexHash
 	return d
 }
 


### PR DESCRIPTION
This adds a feature flag for hash indexes (CREATE INDEX ... USING HASH ... ), that are supported by e.g. PG and MySQL, but not SQLite