### PR TITLE
feat: add IndexHash to feature flags

### DIFF
--- a/dialect/feature/feature.go
+++ b/dialect/feature/feature.go
@@ -21,4 +21,5 @@ const (
 	InsertOnConflict     // INSERT ... ON CONFLICT
 	InsertOnDuplicateKey // INSERT ... ON DUPLICATE KEY
 	InsertIgnore         // INSERT IGNORE ...
+	IndexHash
 )

--- a/dialect/feature/feature.go
+++ b/dialect/feature/feature.go
@@ -1,8 +1,14 @@
 package feature
 
-import "github.com/uptrace/bun/internal"
+import (
+	"errors"
+
+	"github.com/uptrace/bun/internal"
+)
 
 type Feature = internal.Flag
+
+var ErrUnsupportedFeature = errors.New("bun: UnsupportedFeature")
 
 const (
 	CTE Feature = 1 << iota

--- a/dialect/mysqldialect/dialect.go
+++ b/dialect/mysqldialect/dialect.go
@@ -34,7 +34,8 @@ func New() *Dialect {
 		feature.ValuesRow |
 		feature.TableTruncate |
 		feature.InsertIgnore |
-		feature.InsertOnDuplicateKey
+		feature.InsertOnDuplicateKey |
+		feature.IndexHash
 	return d
 }
 

--- a/dialect/pgdialect/dialect.go
+++ b/dialect/pgdialect/dialect.go
@@ -33,7 +33,8 @@ func New() *Dialect {
 		feature.TableCascade |
 		feature.TableIdentity |
 		feature.TableTruncate |
-		feature.InsertOnConflict
+		feature.InsertOnConflict |
+		feature.IndexHash
 	return d
 }
 

--- a/query_index_create.go
+++ b/query_index_create.go
@@ -3,7 +3,9 @@ package bun
 import (
 	"context"
 	"database/sql"
+	"strings"
 
+	"github.com/uptrace/bun/dialect/feature"
 	"github.com/uptrace/bun/internal"
 	"github.com/uptrace/bun/schema"
 )
@@ -93,6 +95,11 @@ func (q *CreateIndexQuery) ModelTableExpr(query string, args ...interface{}) *Cr
 }
 
 func (q *CreateIndexQuery) Using(query string, args ...interface{}) *CreateIndexQuery {
+	if strings.EqualFold(query, "HASH") && !q.db.features.Has(feature.IndexHash) {
+		q.err = feature.ErrUnsupportedFeature
+		return q
+	}
+
 	q.using = schema.SafeQuery(query, args)
 	return q
 }


### PR DESCRIPTION
This adds IndexHash feature to indicate DB engine supports HASH indexes (CREATE INDEX ... USING HASH ...)
e.g. PG and MySQL both support this, while SQLite does not.