### PR TITLE
feat(insert): get last insert id only with pk support auto increment

### DIFF
--- a/query_insert.go
+++ b/query_insert.go
@@ -588,7 +588,7 @@ func (q *InsertQuery) afterInsertHook(ctx context.Context) error {
 }
 
 func (q *InsertQuery) tryLastInsertID(res sql.Result, dest []interface{}) error {
-	if q.db.features.Has(feature.Returning) || q.table == nil || len(q.table.PKs) != 1 {
+	if q.db.features.Has(feature.Returning) || q.table == nil || len(q.table.PKs) != 1 || !q.table.PKs[0].AutoIncrement {
 		return nil
 	}
 


### PR DESCRIPTION
Should we try to get last insert id only with table's pk support auto incrment?
This may make incompatible upgrade!

Or can we support some option to user?

In my case, i use string as pk.