### PR TITLE
feat: add soft_delete partial index creation to unsure "unique"

### DIFF
--- a/dialect/feature/feature.go
+++ b/dialect/feature/feature.go
@@ -21,4 +21,5 @@ const (
 	InsertOnConflict     // INSERT ... ON CONFLICT
 	InsertOnDuplicateKey // INSERT ... ON DUPLICATE KEY
 	InsertIgnore         // INSERT IGNORE ...
+	PartialIndex
 )

--- a/dialect/pgdialect/dialect.go
+++ b/dialect/pgdialect/dialect.go
@@ -42,7 +42,8 @@ func New() *Dialect {
 		feature.TableCascade |
 		feature.TableIdentity |
 		feature.TableTruncate |
-		feature.InsertOnConflict
+		feature.InsertOnConflict |
+		feature.PartialIndex
 	return d
 }
 

--- a/dialect/sqlitedialect/dialect.go
+++ b/dialect/sqlitedialect/dialect.go
@@ -34,7 +34,8 @@ func New() *Dialect {
 		feature.InsertReturning |
 		feature.InsertTableAlias |
 		feature.DeleteTableAlias |
-		feature.InsertOnConflict
+		feature.InsertOnConflict |
+		feature.PartialIndex
 	return d
 }
 

--- a/internal/dbtest/query_test.go
+++ b/internal/dbtest/query_test.go
@@ -401,7 +401,7 @@ func TestQuery(t *testing.T) {
 				Time bun.NullTime
 			}
 			models := make([]Model, 2)
-			models[1].Time = bun.NullTime{Time: time.Unix(0, 0)}
+			models[1].Time = bun.NullTime{Time: time.Unix(0, 0).UTC()}
 			return db.NewValues(&models)
 		},
 		func(db *bun.DB) schema.QueryAppender {
@@ -570,7 +570,7 @@ func TestQuery(t *testing.T) {
 				ID   int64
 				Time time.Time
 			}
-			return db.NewInsert().Model(&Model{ID: 123, Time: time.Unix(0, 0)})
+			return db.NewInsert().Model(&Model{ID: 123, Time: time.Unix(0, 0).UTC()})
 		},
 		func(db *bun.DB) schema.QueryAppender {
 			return db.NewInsert().ColumnExpr("id, name").Table("dest").Table("src")


### PR DESCRIPTION
* Should be enabled for ms-sql as well 
https://docs.microsoft.com/en-us/sql/t-sql/statements/create-index-transact-sql?view=sql-server-ver15#syntax 
* mysql is tricky. 
Common approach is to use `CREATE UNIQUE INDEX team_members_role_team_unique_key ON team_members (role, team, active) ` where `active` is bool DEFAULT 1 that can be used instead of actual safe_delete to unsure uniqueness
Obviously field `active` should be updated along with soft_delete field for that