### PR TITLE
feat(config.go): add connect_timeout to DSN parsable params

### DIFF
--- a/driver/pgdriver/config.go
+++ b/driver/pgdriver/config.go
@@ -263,6 +263,9 @@ func parseDSN(dsn string) ([]Option, error) {
 	if d := q.duration("dial_timeout"); d != 0 {
 		opts = append(opts, WithDialTimeout(d))
 	}
+	if d := q.duration("connect_timeout"); d != 0 {
+		opts = append(opts, WithDialTimeout(d))
+	}
 	if d := q.duration("read_timeout"); d != 0 {
 		opts = append(opts, WithReadTimeout(d))
 	}

--- a/driver/pgdriver/config_test.go
+++ b/driver/pgdriver/config_test.go
@@ -97,6 +97,19 @@ func TestParseDSN(t *testing.T) {
 				WriteTimeout: 5 * time.Second,
 			},
 		},
+		{
+			dsn: "postgres://user:password@localhost:5432/testDatabase?connect_timeout=3",
+			cfg: &pgdriver.Config{
+				Network:      "tcp",
+				Addr:         "localhost:5432",
+				User:         "user",
+				Password:     "password",
+				Database:     "testDatabase",
+				DialTimeout:  3 * time.Second,
+				ReadTimeout:  10 * time.Second,
+				WriteTimeout: 5 * time.Second,
+			},
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Given a DSN using `libpq`'s `connect_timeout` parameter, parses it as `WithDialTimeout`.

closes #505