### PR TITLE
feat: add support for ON UPDATE and ON DELETE rules on belongs-to relationships from struct tags

### DIFF
--- a/internal/dbtest/db_test.go
+++ b/internal/dbtest/db_test.go
@@ -879,7 +879,7 @@ func testWithForeignKeys(t *testing.T, db *bun.DB) {
 		ID       int `bun:",pk,autoincrement"`
 		UserID   int
 		UserType string
-		User     *User `bun:"rel:belongs-to,join:user_id=id,join:user_type=type"`
+		User     *User `bun:"rel:belongs-to,join:user_id=id,join:user_type=type,on_update:cascade,on_delete:set null"`
 	}
 
 	if db.Dialect().Name() == dialect.SQLite {

--- a/query_table_create.go
+++ b/query_table_create.go
@@ -105,13 +105,16 @@ func (q *CreateTableQuery) TableSpace(tablespace string) *CreateTableQuery {
 func (q *CreateTableQuery) WithForeignKeys() *CreateTableQuery {
 	for _, relation := range q.tableModel.Table().Relations {
 		if relation.Type == schema.ManyToManyRelation ||
-		    relation.Type == schema.HasManyRelation {
+			relation.Type == schema.HasManyRelation {
 			continue
-		}		
-		q = q.ForeignKey("(?) REFERENCES ? (?)",
+		}
+
+		q = q.ForeignKey("(?) REFERENCES ? (?) ? ?",
 			Safe(appendColumns(nil, "", relation.BaseFields)),
 			relation.JoinTable.SQLName,
 			Safe(appendColumns(nil, "", relation.JoinFields)),
+			Safe(relation.OnUpdate),
+			Safe(relation.OnDelete),
 		)
 	}
 	return q

--- a/schema/relation.go
+++ b/schema/relation.go
@@ -18,6 +18,8 @@ type Relation struct {
 	JoinTable  *Table
 	BaseFields []*Field
 	JoinFields []*Field
+	OnUpdate   string
+	OnDelete   string
 
 	PolymorphicField *Field
 	PolymorphicValue string

--- a/schema/table.go
+++ b/schema/table.go
@@ -479,6 +479,35 @@ func (t *Table) belongsToRelation(field *Field) *Relation {
 		JoinTable: joinTable,
 	}
 
+	rel.OnUpdate = "ON DELETE NO ACTION"
+	if onUpdate, ok := field.Tag.Options["on_update"]; ok {
+		if len(onUpdate) > 1 {
+			panic(fmt.Errorf("bun: %s belongs-to %s: on_update option must be a single field", t.TypeName, field.GoName))
+		}
+
+		rule := strings.ToUpper(onUpdate[0])
+		if !isKnownFKRule(rule) {
+			internal.Warn.Printf("bun: %s belongs-to %s: unknown on_update rule %s", t.TypeName, field.GoName, rule)
+		}
+
+		s := fmt.Sprintf("ON UPDATE %s", rule)
+		rel.OnUpdate = s
+	}
+
+	rel.OnDelete = "ON DELETE NO ACTION"
+	if onDelete, ok := field.Tag.Options["on_delete"]; ok {
+		if len(onDelete) > 1 {
+			panic(fmt.Errorf("bun: %s belongs-to %s: on_delete option must be a single field", t.TypeName, field.GoName))
+		}
+
+		rule := strings.ToUpper(onDelete[0])
+		if !isKnownFKRule(rule) {
+			internal.Warn.Printf("bun: %s belongs-to %s: unknown on_delete rule %s", t.TypeName, field.GoName, rule)
+		}
+		s := fmt.Sprintf("ON DELETE %s", rule)
+		rel.OnDelete = s
+	}
+
 	if join, ok := field.Tag.Options["join"]; ok {
 		baseColumns, joinColumns := parseRelationJoin(join)
 		for i, baseColumn := range baseColumns {
@@ -859,8 +888,21 @@ func isKnownFieldOption(name string) bool {
 		"autoincrement",
 		"rel",
 		"join",
+		"on_update",
+		"on_delete",
 		"m2m",
 		"polymorphic":
+		return true
+	}
+	return false
+}
+
+func isKnownFKRule(name string) bool {
+	switch name {
+	case "CASCADE",
+		"RESTRICT",
+		"SET NULL",
+		"SET DEFAULT":
 		return true
 	}
 	return false

--- a/schema/table.go
+++ b/schema/table.go
@@ -479,7 +479,7 @@ func (t *Table) belongsToRelation(field *Field) *Relation {
 		JoinTable: joinTable,
 	}
 
-	rel.OnUpdate = "ON DELETE NO ACTION"
+	rel.OnUpdate = "ON UPDATE NO ACTION"
 	if onUpdate, ok := field.Tag.Options["on_update"]; ok {
 		if len(onUpdate) > 1 {
 			panic(fmt.Errorf("bun: %s belongs-to %s: on_update option must be a single field", t.TypeName, field.GoName))


### PR DESCRIPTION
I was missing this feature from `go-pg` and wanted to add it to the codebase. AFAIK `belongs-to` is the only rel that would benefit from it, as it's the only one that generates a column on the DB. But I still don't know this repo as deeply as I want to, so feel free to correct me. 

```golang
type User struct {
		ID   int    `bun:",pk,autoincrement"`
		Type string `bun:",pk"`
		Name string
}
type Deck struct {
		ID       int `bun:",pk,autoincrement"`
		UserID   int
		UserType string
		User     *User `bun:"rel:belongs-to,join:user_id=id,join:user_type=type,on_update:cascade,on_delete:set null"`
}
```

Also, should I tag the release for this?