### PR TITLE
fix: handle invalid value on fieldByIndex

### DIFF
--- a/schema/reflect.go
+++ b/schema/reflect.go
@@ -30,6 +30,9 @@ func indirectType(t reflect.Type) reflect.Type {
 
 func fieldByIndex(v reflect.Value, index []int) (_ reflect.Value, ok bool) {
 	if len(index) == 1 {
+		if !v.IsValid() {
+			return v, false
+		}
 		return v.Field(index[0]), true
 	}
 
@@ -41,6 +44,9 @@ func fieldByIndex(v reflect.Value, index []int) (_ reflect.Value, ok bool) {
 				}
 				v = v.Elem()
 			}
+		}
+		if !v.IsValid() {
+			return v, false
 		}
 		v = v.Field(idx)
 	}


### PR DESCRIPTION
When using deep `Relation()` with `Scan(ctx)`, if the value we're scanning is invalid (usually zero), then bun currently panics when attempting `v.Field(idx)`

Let's handle that correctly before trying to apply it.