### PR TITLE
feat(bunotel): add option to enable formatting of queries

### DIFF
--- a/extra/bunotel/option.go
+++ b/extra/bunotel/option.go
@@ -20,3 +20,13 @@ func WithDBName(name string) Option {
 		h.attrs = append(h.attrs, semconv.DBNameKey.String(name))
 	}
 }
+
+// WithFormatting enables formatting of the query that is added
+// as the statement attribute to the trace.
+// This means that all placeholders and arguments will be filled first
+// and the query will contain all information as sent to the database.
+func WithFormatting() Option {
+	return func(h *QueryHook) {
+		h.formatting = true
+	}
+}

--- a/extra/bunotel/option.go
+++ b/extra/bunotel/option.go
@@ -21,12 +21,12 @@ func WithDBName(name string) Option {
 	}
 }
 
-// WithFormatting enables formatting of the query that is added
+// WithFormattedQueries enables formatting of the query that is added
 // as the statement attribute to the trace.
 // This means that all placeholders and arguments will be filled first
 // and the query will contain all information as sent to the database.
-func WithFormatting() Option {
+func WithFormattedQueries(format bool) Option {
 	return func(h *QueryHook) {
-		h.formatting = true
+		h.formatQueries = format
 	}
 }

--- a/extra/bunotel/otel.go
+++ b/extra/bunotel/otel.go
@@ -33,8 +33,8 @@ var (
 )
 
 type QueryHook struct {
-	attrs      []attribute.KeyValue
-	formatting bool
+	attrs         []attribute.KeyValue
+	formatQueries bool
 }
 
 var _ bun.QueryHook = (*QueryHook)(nil)
@@ -148,7 +148,7 @@ func (h *QueryHook) eventQuery(event *bun.QueryEvent) string {
 
 	var query string
 
-	if h.formatting && len(event.Query) <= softQueryLimit {
+	if h.formatQueries && len(event.Query) <= softQueryLimit {
 		query = event.Query
 	} else {
 		query = unformattedQuery(event)

--- a/extra/bunotel/otel.go
+++ b/extra/bunotel/otel.go
@@ -33,7 +33,8 @@ var (
 )
 
 type QueryHook struct {
-	attrs []attribute.KeyValue
+	attrs      []attribute.KeyValue
+	formatting bool
 }
 
 var _ bun.QueryHook = (*QueryHook)(nil)
@@ -83,7 +84,7 @@ func (h *QueryHook) AfterQuery(ctx context.Context, event *bun.QueryEvent) {
 	span.SetName(operation)
 	defer span.End()
 
-	query := eventQuery(event)
+	query := h.eventQuery(event)
 	fn, file, line := funcFileLine("github.com/uptrace/bun")
 
 	attrs := make([]attribute.KeyValue, 0, 10)
@@ -141,13 +142,13 @@ func funcFileLine(pkg string) (string, string, int) {
 	return fn, file, line
 }
 
-func eventQuery(event *bun.QueryEvent) string {
+func (h *QueryHook) eventQuery(event *bun.QueryEvent) string {
 	const softQueryLimit = 8000
 	const hardQueryLimit = 16000
 
 	var query string
 
-	if len(event.Query) <= softQueryLimit {
+	if h.formatting && len(event.Query) <= softQueryLimit {
 		query = event.Query
 	} else {
 		query = unformattedQuery(event)


### PR DESCRIPTION
Disable formatting by default (breaing change)
and add bunotel option that enables formatting.

Formatting has potential to leak information into the traces
as such not formatting the query by default seems like
safer option.

Fixes: https://github.com/uptrace/bun/issues/546