### PR TITLE
feat: add tx methods to IDB (#587)

### DIFF
--- a/dialect/feature/feature.go
+++ b/dialect/feature/feature.go
@@ -29,4 +29,5 @@ const (
 	OffsetFetch
 	SelectExists
 	UpdateFromTable
+	MSSavepoint
 )

--- a/dialect/mssqldialect/dialect.go
+++ b/dialect/mssqldialect/dialect.go
@@ -46,7 +46,8 @@ func New() *Dialect {
 		feature.Identity |
 		feature.Output |
 		feature.OffsetFetch |
-		feature.UpdateFromTable
+		feature.UpdateFromTable |
+		feature.MSSavepoint
 	return d
 }
 

--- a/query_base.go
+++ b/query_base.go
@@ -57,6 +57,9 @@ type IDB interface {
 	NewTruncateTable() *TruncateTableQuery
 	NewAddColumn() *AddColumnQuery
 	NewDropColumn() *DropColumnQuery
+
+	BeginTx(ctx context.Context, opts *sql.TxOptions) (Tx, error)
+	RunInTx(ctx context.Context, opts *sql.TxOptions, f func(ctx context.Context, tx Tx) error) error
 }
 
 var (


### PR DESCRIPTION
Updated `IDB` interface with 2 methods

```
BeginTx(ctx context.Context, opts *sql.TxOptions) (Tx, error)
RunInTx(ctx context.Context, opts *sql.TxOptions, f func(ctx context.Context, tx Tx) error) error
```

When creating a savepoint the `opts` are ignored.
Currently the transaction will not use the name but we can store something like `TX_{random}` same format as for savepoint. Then we can also emit the name with the hooks so logging libraries can show if a query is being executed as part of a transaction or savepoint.