### PR TITLE
fix(migrate): value type receivers for Migration and MigrationGroup

### DIFF
--- a/migrate/migration.go
+++ b/migrate/migration.go
@@ -232,11 +232,11 @@ type MigrationGroup struct {
 	Migrations MigrationSlice
 }
 
-func (g *MigrationGroup) IsZero() bool {
+func (g MigrationGroup) IsZero() bool {
 	return g.ID == 0 && len(g.Migrations) == 0
 }
 
-func (g *MigrationGroup) String() string {
+func (g MigrationGroup) String() string {
 	if g.IsZero() {
 		return "nil"
 	}

--- a/migrate/migration.go
+++ b/migrate/migration.go
@@ -25,11 +25,11 @@ type Migration struct {
 	Down MigrationFunc `bun:"-"`
 }
 
-func (m *Migration) String() string {
+func (m Migration) String() string {
 	return m.Name
 }
 
-func (m *Migration) IsApplied() bool {
+func (m Migration) IsApplied() bool {
 	return m.ID > 0
 }
 


### PR DESCRIPTION
There are inconsistencies in the receiver types on the methods of `Migration`, `MigrationGroup` and `MigrationSlice`:
- `Migration` is read-only from this package's perspective, and appears as `Migration` mostly, but the receiver is `*Migration`
- `MigrationGroup` is read-only as well from this package's perspective but it is used everywhere as `*MigrationGroup`
- `MigrationSlice` has underlying type `[]Migration` and is used as `MigrationSlice` everywhere

We stumbled upon this when trying something like (of course the following code is simplified):
```go
migrations := migrate.NewMigrations()
for _, m := range migrations.Sorted() {
    fmt.Printf("migration: %s\n", m) // m does not implement fmt.Stringer since the String method is implemented on *Migration but MigrationSlice is []Migration
}
```

Removing these inconsistencies has other advantages:
- Emphasize that those types are read-only, i.e. the `migrate` package does not mutate a value after returning it, or keep it as a cache...
- Reduce complexity in usage

This fixes #601 