### PR TITLE
fix: bunotel add set attributes to query metrics

### DIFF
--- a/extra/bunotel/otel.go
+++ b/extra/bunotel/otel.go
@@ -66,7 +66,8 @@ func (h *QueryHook) AfterQuery(ctx context.Context, event *bun.QueryEvent) {
 	operation := event.Operation()
 	dbOperation := semconv.DBOperationKey.String(operation)
 
-	labels := make([]attribute.KeyValue, 0, 2)
+	labels := make([]attribute.KeyValue, 0, len(h.attrs)+2)
+	labels = append(labels, h.attrs...)
 	labels = append(labels, dbOperation)
 	if event.IQuery != nil {
 		if tableName := event.IQuery.GetTableName(); tableName != "" {


### PR DESCRIPTION
Currently, even if we set attributes with `WithAttributes`, they are not set for query metrics, only pool/connections metrics. This PR fixes this issue.