### PR TITLE
fix(pgdriver): return first error if readMessageType errors

### DIFF
--- a/driver/pgdriver/proto.go
+++ b/driver/pgdriver/proto.go
@@ -1026,7 +1026,14 @@ func readError(rd *reader) (error, error) {
 		}
 		m[c] = s
 	}
-	return Error{m: m}, nil
+	switch err := (Error{m: m}); err.Field('V') {
+	case "FATAL", "PANIC":
+		// Return this as an error and stop processing.
+		return nil, err
+	default:
+		// Return this as an error message and continue processing.
+		return err, nil
+	}
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This pull request contributes a fix for https://github.com/uptrace/bun/issues/525 that I was able to reproduce by making PostgreSQL close client connections (first revision of https://gist.github.com/htdvisser/fe1145e832fe2f323ee609e866fb59be).

Before the server closes the client connection, it sends a `57P01 terminating connection due to administrator command`. This error is however not returned by the read loops, which instead return the EOF coming from trying to read the next message.

~This pull request changes the read loops to check if there's a `firstErr` to return before returning the error returned by `readMessageType` (which in my experiment was usually a `read tcp [::1]:***->[::1]:5432: read: connection reset by peer`, but occasionally an `EOF`).~

EDIT: Updated, see comments.

I've verified that the seemingly random EOFs no longer occur in the last revision of https://gist.github.com/htdvisser/fe1145e832fe2f323ee609e866fb59be that replaces `pgdriver` with my fork.