### PR TITLE
feat(pgdriver): Implement database/sql/driver.SessionResetter

### DIFF
--- a/driver/pgdriver/config.go
+++ b/driver/pgdriver/config.go
@@ -42,6 +42,9 @@ type Config struct {
 	ReadTimeout time.Duration
 	// Timeout for socket writes. If reached, commands fail with a timeout instead of blocking.
 	WriteTimeout time.Duration
+
+	// ResetSessionFunc is called prior to executing a query on a connection that has been used before.
+	ResetSessionFunc func(context.Context, *Conn) error
 }
 
 func newDefaultConfig() *Config {
@@ -170,6 +173,15 @@ func WithReadTimeout(readTimeout time.Duration) Option {
 func WithWriteTimeout(writeTimeout time.Duration) Option {
 	return func(cfg *Config) {
 		cfg.WriteTimeout = writeTimeout
+	}
+}
+
+// WithResetSessionFunc configures a function that is called prior to executing
+// a query on a connection that has been used before.
+// If the func returns driver.ErrBadConn, the connection is discarded.
+func WithResetSessionFunc(fn func(context.Context, *Conn) error) Option {
+	return func(cfg *Config) {
+		cfg.ResetSessionFunc = fn
 	}
 }
 

--- a/driver/pgdriver/driver.go
+++ b/driver/pgdriver/driver.go
@@ -349,6 +349,8 @@ func (cn *Conn) checkBadConn(err error) error {
 	return err
 }
 
+func (cn *Conn) Conn() net.Conn { return cn.netConn }
+
 //------------------------------------------------------------------------------
 
 type rows struct {

--- a/driver/pgdriver/driver.go
+++ b/driver/pgdriver/driver.go
@@ -328,6 +328,18 @@ func (cn *Conn) IsValid() bool {
 	return !cn.isClosed()
 }
 
+var _ driver.SessionResetter = (*Conn)(nil)
+
+func (cn *Conn) ResetSession(ctx context.Context) error {
+	if cn.isClosed() {
+		return driver.ErrBadConn
+	}
+	if cn.cfg.ResetSessionFunc != nil {
+		return cn.cfg.ResetSessionFunc(ctx, cn)
+	}
+	return nil
+}
+
 func (cn *Conn) checkBadConn(err error) error {
 	if isBadConn(err, false) {
 		// Close and return driver.ErrBadConn next time the conn is used.


### PR DESCRIPTION
This pull request implements the [`SessionResetter` interface](https://pkg.go.dev/database/sql/driver#SessionResetter) on `pgdriver.Conn`.

The `SessionResetter` can be useful to detect a closed or bad connection _before_ we're trying to run queries on it. To make this work, we'd need some way to get the underlying `net.Conn` from `*pgdriver.Conn`, so I added a `Conn() net.Conn` method for that. This is similar to how `*pgx.Conn` lets you [get the underlying `*pgconn.PgConn`](https://pkg.go.dev/github.com/jackc/pgx/v4#Conn.PgConn).