### PR TITLE
fix: relation join soft delete SQL generate

### DIFF
--- a/internal/dbtest/query_test.go
+++ b/internal/dbtest/query_test.go
@@ -902,6 +902,22 @@ func TestQuery(t *testing.T) {
 			}
 			return db.NewCreateTable().Model(new(User))
 		},
+		func(db *bun.DB) schema.QueryAppender {
+			type Model struct {
+				ID           int64 `bun:",pk,autoincrement"`
+				SoftDeleteID int64
+				SoftDelete   *SoftDelete1 `bun:"rel:belongs-to"`
+			}
+			return db.NewSelect().Model(new(Model)).Relation("SoftDelete")
+		},
+		func(db *bun.DB) schema.QueryAppender {
+			type Model struct {
+				ID           int64 `bun:",pk,autoincrement"`
+				SoftDeleteID int64
+				SoftDelete   *SoftDelete2 `bun:"rel:belongs-to"`
+			}
+			return db.NewSelect().Model(new(Model)).Relation("SoftDelete")
+		},
 	}
 
 	timeRE := regexp.MustCompile(`'2\d{3}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(\.\d+)?(\+\d{2}:\d{2})?'`)

--- a/internal/dbtest/testdata/snapshots/TestQuery-mariadb-152
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mariadb-152
@@ -1,0 +1,1 @@
+SELECT `model`.`id`, `model`.`soft_delete_id`, `soft_delete`.`id` AS `soft_delete__id`, `soft_delete`.`deleted_at` AS `soft_delete__deleted_at` FROM `models` AS `model` LEFT JOIN `soft_deletes` AS `soft_delete` ON (`soft_delete`.`id` = `model`.`soft_delete_id`) AND `soft_delete`.`deleted_at` IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-mariadb-153
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mariadb-153
@@ -1,0 +1,1 @@
+SELECT `model`.`id`, `model`.`soft_delete_id`, `soft_delete`.`id` AS `soft_delete__id`, `soft_delete`.`deleted_at` AS `soft_delete__deleted_at` FROM `models` AS `model` LEFT JOIN `soft_deletes` AS `soft_delete` ON (`soft_delete`.`id` = `model`.`soft_delete_id`) AND `soft_delete`.`deleted_at` = '0001-01-01 00:00:00'

--- a/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-152
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-152
@@ -1,0 +1,1 @@
+SELECT "model"."id", "model"."soft_delete_id", "soft_delete"."id" AS "soft_delete__id", "soft_delete"."deleted_at" AS "soft_delete__deleted_at" FROM "models" AS "model" LEFT JOIN "soft_deletes" AS "soft_delete" ON ("soft_delete"."id" = "model"."soft_delete_id") AND "soft_delete"."deleted_at" IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-153
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-153
@@ -1,0 +1,1 @@
+SELECT "model"."id", "model"."soft_delete_id", "soft_delete"."id" AS "soft_delete__id", "soft_delete"."deleted_at" AS "soft_delete__deleted_at" FROM "models" AS "model" LEFT JOIN "soft_deletes" AS "soft_delete" ON ("soft_delete"."id" = "model"."soft_delete_id") AND "soft_delete"."deleted_at" = '0001-01-01 00:00:00'

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql5-152
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql5-152
@@ -1,0 +1,1 @@
+SELECT `model`.`id`, `model`.`soft_delete_id`, `soft_delete`.`id` AS `soft_delete__id`, `soft_delete`.`deleted_at` AS `soft_delete__deleted_at` FROM `models` AS `model` LEFT JOIN `soft_deletes` AS `soft_delete` ON (`soft_delete`.`id` = `model`.`soft_delete_id`) AND `soft_delete`.`deleted_at` IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql5-153
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql5-153
@@ -1,0 +1,1 @@
+SELECT `model`.`id`, `model`.`soft_delete_id`, `soft_delete`.`id` AS `soft_delete__id`, `soft_delete`.`deleted_at` AS `soft_delete__deleted_at` FROM `models` AS `model` LEFT JOIN `soft_deletes` AS `soft_delete` ON (`soft_delete`.`id` = `model`.`soft_delete_id`) AND `soft_delete`.`deleted_at` = '0001-01-01 00:00:00'

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql8-152
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql8-152
@@ -1,0 +1,1 @@
+SELECT `model`.`id`, `model`.`soft_delete_id`, `soft_delete`.`id` AS `soft_delete__id`, `soft_delete`.`deleted_at` AS `soft_delete__deleted_at` FROM `models` AS `model` LEFT JOIN `soft_deletes` AS `soft_delete` ON (`soft_delete`.`id` = `model`.`soft_delete_id`) AND `soft_delete`.`deleted_at` IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql8-153
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql8-153
@@ -1,0 +1,1 @@
+SELECT `model`.`id`, `model`.`soft_delete_id`, `soft_delete`.`id` AS `soft_delete__id`, `soft_delete`.`deleted_at` AS `soft_delete__deleted_at` FROM `models` AS `model` LEFT JOIN `soft_deletes` AS `soft_delete` ON (`soft_delete`.`id` = `model`.`soft_delete_id`) AND `soft_delete`.`deleted_at` = '0001-01-01 00:00:00'

--- a/internal/dbtest/testdata/snapshots/TestQuery-pg-152
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pg-152
@@ -1,0 +1,1 @@
+SELECT "model"."id", "model"."soft_delete_id", "soft_delete"."id" AS "soft_delete__id", "soft_delete"."deleted_at" AS "soft_delete__deleted_at" FROM "models" AS "model" LEFT JOIN "soft_deletes" AS "soft_delete" ON ("soft_delete"."id" = "model"."soft_delete_id") AND "soft_delete"."deleted_at" IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-pg-153
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pg-153
@@ -1,0 +1,1 @@
+SELECT "model"."id", "model"."soft_delete_id", "soft_delete"."id" AS "soft_delete__id", "soft_delete"."deleted_at" AS "soft_delete__deleted_at" FROM "models" AS "model" LEFT JOIN "soft_deletes" AS "soft_delete" ON ("soft_delete"."id" = "model"."soft_delete_id") AND "soft_delete"."deleted_at" = '0001-01-01 00:00:00+00:00'

--- a/internal/dbtest/testdata/snapshots/TestQuery-pgx-152
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pgx-152
@@ -1,0 +1,1 @@
+SELECT "model"."id", "model"."soft_delete_id", "soft_delete"."id" AS "soft_delete__id", "soft_delete"."deleted_at" AS "soft_delete__deleted_at" FROM "models" AS "model" LEFT JOIN "soft_deletes" AS "soft_delete" ON ("soft_delete"."id" = "model"."soft_delete_id") AND "soft_delete"."deleted_at" IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-pgx-153
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pgx-153
@@ -1,0 +1,1 @@
+SELECT "model"."id", "model"."soft_delete_id", "soft_delete"."id" AS "soft_delete__id", "soft_delete"."deleted_at" AS "soft_delete__deleted_at" FROM "models" AS "model" LEFT JOIN "soft_deletes" AS "soft_delete" ON ("soft_delete"."id" = "model"."soft_delete_id") AND "soft_delete"."deleted_at" = '0001-01-01 00:00:00+00:00'

--- a/internal/dbtest/testdata/snapshots/TestQuery-sqlite-152
+++ b/internal/dbtest/testdata/snapshots/TestQuery-sqlite-152
@@ -1,0 +1,1 @@
+SELECT "model"."id", "model"."soft_delete_id", "soft_delete"."id" AS "soft_delete__id", "soft_delete"."deleted_at" AS "soft_delete__deleted_at" FROM "models" AS "model" LEFT JOIN "soft_deletes" AS "soft_delete" ON ("soft_delete"."id" = "model"."soft_delete_id") AND "soft_delete"."deleted_at" IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-sqlite-153
+++ b/internal/dbtest/testdata/snapshots/TestQuery-sqlite-153
@@ -1,0 +1,1 @@
+SELECT "model"."id", "model"."soft_delete_id", "soft_delete"."id" AS "soft_delete__id", "soft_delete"."deleted_at" AS "soft_delete__deleted_at" FROM "models" AS "model" LEFT JOIN "soft_deletes" AS "soft_delete" ON ("soft_delete"."id" = "model"."soft_delete_id") AND "soft_delete"."deleted_at" = '0001-01-01 00:00:00+00:00'


### PR DESCRIPTION
When I used "Table relationships" to query, I found that the output was incorrect, and checked the logs to find that there was a problem generating the SQL statement in the soft delete position, so I fixed it.

I refer to the soft delete handling code in the `query_base.go` file.

https://github.com/uptrace/bun/blob/28915f89b0e864ee7c43782fe3234f8d65831e00/query_base.go#L806-L822

### Problem Reproduction

The database I use is PostgreSQL, and the model I defined is as follows:

```go
type User struct {
    bun.BaseModel `bun:"user"`
    ID            string    `bun:"type:TEXT,pk" json:"id"`
    Name          string    `bun:"name,type:TEXT" json:"name"`
    Deleted       time.Time `bun:"deleted,soft_delete" json:"-"`
    Created       time.Time `bun:"created" json:"created"`
    Updated       time.Time `bun:"updated" json:"updated"`
}

type UserToGroup struct {
    bun.BaseModel `bun:"user_to_group"`
    ID            string    `bun:"type:TEXT,pk" json:"id"`
    UserID        string    `bun:"user_id,type:TEXT"`
    User          *User     `bun:"rel:belongs-to,join:user_id=id"`
    Deleted       time.Time `bun:"deleted,soft_delete" json:"-"`
    Created       time.Time `bun:"created" json:"created"`
    Updated       time.Time `bun:"updated" json:"updated"`
}
```

The query statement I use is:

```go
item := UserToGroup{
    ID: "01832d6de013d76b41bd51c4",
}

db.NewSelect().Model(&item).Relation("User").WherePK().Scan(ctx)
```

The generated SQL statement is:

```sql
SELECT "user_to_group"."id", "user_to_group"."user_id", "user_to_group"."deleted", "user_to_group"."created", "user_to_group"."updated", "user"."id" AS "user__id", "user"."name" AS "user__name", "user"."deleted" AS "user__deleted", "user"."created" AS "user__created", "user"."updated" AS "user__updated" FROM "user_to_group" LEFT JOIN "user" AS "user" ON ("user"."id" = "user_to_group"."user_id") AND "user"."deleted" IS NULL WHERE "user_to_group"."deleted" = '0001-01-01 00:00:00+00:00' AND ("user_to_group"."id" = '01832d6de013d76b41bd51c4')
```
As you can see, I did not use the `nullzero option`, but the generated SQL statement is `AND "user"."deleted" IS NULL`.

The SQL statement generated after the fix is as follows:

```sql
SELECT "user_to_group"."id", "user_to_group"."user_id", "user_to_group"."deleted", "user_to_group"."created", "user_to_group"."updated", "user"."id" AS "user__id", "user"."name" AS "user__name", "user"."deleted" AS "user__deleted", "user"."created" AS "user__created", "user"."updated" AS "user__updated" FROM "user_to_group" LEFT JOIN "user" AS "user" ON ("user"."id" = "user_to_group"."user_id") AND "user"."deleted" = '0001-01-01 00:00:00+00:00' WHERE "user_to_group"."deleted" = '0001-01-01 00:00:00+00:00' AND ("user_to_group"."id" = '01832d6de013d76b41bd51c4')
```