### PR TITLE
fix(query): make WhereDeleted compatible with ForceDelete

### DIFF
--- a/query_base.go
+++ b/query_base.go
@@ -238,7 +238,7 @@ func (q *baseQuery) isSoftDelete() bool {
 	if q.table != nil {
 		return q.table.SoftDeleteField != nil &&
 			!q.flags.Has(allWithDeletedFlag) &&
-			!q.flags.Has(forceDeleteFlag)
+			(!q.flags.Has(forceDeleteFlag) || q.flags.Has(deletedFlag))
 	}
 	return false
 }
@@ -773,7 +773,7 @@ func (q *whereBaseQuery) addWhereCols(cols []string) {
 func (q *whereBaseQuery) mustAppendWhere(
 	fmter schema.Formatter, b []byte, withAlias bool,
 ) ([]byte, error) {
-	if len(q.where) == 0 && q.whereFields == nil {
+	if len(q.where) == 0 && q.whereFields == nil && !q.flags.Has(deletedFlag) {
 		err := errors.New("bun: Update and Delete queries require at least one Where")
 		return nil, err
 	}

--- a/query_delete.go
+++ b/query_delete.go
@@ -163,7 +163,6 @@ func (q *DeleteQuery) AppendQuery(fmter schema.Formatter, b []byte) (_ []byte, e
 		return upd.AppendQuery(fmter, b)
 	}
 
-	q = q.WhereDeleted()
 	withAlias := q.db.features.Has(feature.DeleteTableAlias)
 
 	b, err = q.appendWith(fmter, b)


### PR DESCRIPTION
As of Bun 1.1.8, `WhereDeleted()` is ignored when used with `ForceDelete()`.

This commit fixes that problem:

```go
db.NewDelete().Model((*Model)(nil)).Where("1 = 1").WhereDeleted().ForceDelete().Exec(ctx)
// Before this commit: DELETE FROM model WHERE 1 = 1
// After this commit:  DELETE FROM model WHERE 1 = 1 AND deleted_at IS NOT NULL
```

Additionally, the `Where("1 = 1")` trick is no longer required as `WhereDeleted()` now counts as a user-defined `WHERE` clause in `mustAppendWhere`:

```go
db.NewDelete().Model((*Model)(nil)).WhereDeleted().ForceDelete().Exec(ctx)
// Before this commit: Errors with "bun: Update and Delete queries require at least one Where"
// After this commit:  DELETE FROM model WHERE deleted_at IS NOT NULL
```

This gives us an easy and natural way to hard delete all soft deleted records.

Fixes #673.