### PR TITLE
feat: Add WithRecursive operation to query

### DIFF
--- a/query_base.go
+++ b/query_base.go
@@ -20,8 +20,9 @@ const (
 )
 
 type withQuery struct {
-	name  string
-	query schema.QueryAppender
+	name      string
+	query     schema.QueryAppender
+	recursive bool
 }
 
 // IConn is a common interface for *sql.DB, *sql.Conn, and *sql.Tx.
@@ -244,10 +245,11 @@ func (q *baseQuery) isSoftDelete() bool {
 
 //------------------------------------------------------------------------------
 
-func (q *baseQuery) addWith(name string, query schema.QueryAppender) {
+func (q *baseQuery) addWith(name string, query schema.QueryAppender, recursive bool) {
 	q.with = append(q.with, withQuery{
-		name:  name,
-		query: query,
+		name:      name,
+		query:     query,
+		recursive: recursive,
 	})
 }
 
@@ -260,6 +262,10 @@ func (q *baseQuery) appendWith(fmter schema.Formatter, b []byte) (_ []byte, err 
 	for i, with := range q.with {
 		if i > 0 {
 			b = append(b, ", "...)
+		}
+
+		if with.recursive {
+			b = append(b, "RECURSIVE "...)
 		}
 
 		b, err = q.appendCTE(fmter, b, with)

--- a/query_delete.go
+++ b/query_delete.go
@@ -45,7 +45,12 @@ func (q *DeleteQuery) Apply(fn func(*DeleteQuery) *DeleteQuery) *DeleteQuery {
 }
 
 func (q *DeleteQuery) With(name string, query schema.QueryAppender) *DeleteQuery {
-	q.addWith(name, query)
+	q.addWith(name, query, false)
+	return q
+}
+
+func (q *DeleteQuery) WithRecursive(name string, query schema.QueryAppender) *DeleteQuery {
+	q.addWith(name, query, true)
 	return q
 }
 

--- a/query_insert.go
+++ b/query_insert.go
@@ -54,7 +54,12 @@ func (q *InsertQuery) Apply(fn func(*InsertQuery) *InsertQuery) *InsertQuery {
 }
 
 func (q *InsertQuery) With(name string, query schema.QueryAppender) *InsertQuery {
-	q.addWith(name, query)
+	q.addWith(name, query, false)
+	return q
+}
+
+func (q *InsertQuery) WithRecursive(name string, query schema.QueryAppender) *InsertQuery {
+	q.addWith(name, query, true)
 	return q
 }
 

--- a/query_select.go
+++ b/query_select.go
@@ -67,7 +67,12 @@ func (q *SelectQuery) Apply(fn func(*SelectQuery) *SelectQuery) *SelectQuery {
 }
 
 func (q *SelectQuery) With(name string, query schema.QueryAppender) *SelectQuery {
-	q.addWith(name, query)
+	q.addWith(name, query, false)
+	return q
+}
+
+func (q *SelectQuery) WithRecursive(name string, query schema.QueryAppender) *SelectQuery {
+	q.addWith(name, query, true)
 	return q
 }
 

--- a/query_update.go
+++ b/query_update.go
@@ -53,7 +53,12 @@ func (q *UpdateQuery) Apply(fn func(*UpdateQuery) *UpdateQuery) *UpdateQuery {
 }
 
 func (q *UpdateQuery) With(name string, query schema.QueryAppender) *UpdateQuery {
-	q.addWith(name, query)
+	q.addWith(name, query, false)
+	return q
+}
+
+func (q *UpdateQuery) WithRecursive(name string, query schema.QueryAppender) *UpdateQuery {
+	q.addWith(name, query, true)
 	return q
 }
 


### PR DESCRIPTION
close #526 

implement method `WithRecursive` for delete insert select and update query. 
```diff
+ func (q *Query) WithRecursive(name string, query schema.QueryAppender) *Query
```

for recursive query
```SQL
WITH RECURSIVE ... (
...
)
```

Ex.
```SQL
WITH RECURSIVE subordinate AS (
    SELECT
        c.id
    FROM
        categories c
    WHERE
        c.id = '7d82f83b-c45e-4020-8f78-dbfda314e684'
    UNION
    all
    SELECT
        c2.id
    FROM
        categories c2
        INNER JOIN subordinate s ON s.id = c2.parent_category_id
)
SELECT
    DISTINCT subordinate.*
FROM
    subordinate
```
```go
subordinate := db.NewSelect().Table("categories").
	Column("categories.id").
	Where("categories.id = ?", id).
	UnionAll(
		db.NewSelect().Table("categories").
			Column("categories.id").
			Join("INNER JOIN subordinate ON subordinate.id = categories.parent_category_id"),
	)
db.NewSelect().
WithRecursive("subordinate",subordinate).
Table("categories").
Join("LEFT JOIN subordinate on true").
Where("categories.id = subordinate.id")
```