### PR TITLE
Adding dialect override for AppendBool

### DIFF
--- a/dialect/mssqldialect/dialect.go
+++ b/dialect/mssqldialect/dialect.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -114,6 +115,16 @@ func (*Dialect) AppendBytes(b, bs []byte) []byte {
 	hex.Encode(b[s:], bs)
 
 	return b
+}
+
+func (*Dialect) AppendBool(b []byte, v bool) []byte {
+	num := 0
+
+	if v {
+		num = 1
+	}
+
+	return strconv.AppendUint(b, uint64(num), 10)
 }
 
 func sqlType(field *schema.Field) string {

--- a/schema/append_value.go
+++ b/schema/append_value.go
@@ -183,7 +183,7 @@ func PtrAppender(fn AppenderFunc) AppenderFunc {
 }
 
 func AppendBoolValue(fmter Formatter, b []byte, v reflect.Value) []byte {
-	return dialect.AppendBool(b, v.Bool())
+	return fmter.Dialect().AppendBool(b, v.Bool())
 }
 
 func AppendIntValue(fmter Formatter, b []byte, v reflect.Value) []byte {

--- a/schema/dialect.go
+++ b/schema/dialect.go
@@ -29,6 +29,7 @@ type Dialect interface {
 	AppendString(b []byte, s string) []byte
 	AppendBytes(b []byte, bs []byte) []byte
 	AppendJSON(b, jsonb []byte) []byte
+	AppendBool(b []byte, v bool) []byte
 }
 
 //------------------------------------------------------------------------------
@@ -124,6 +125,10 @@ func (BaseDialect) AppendJSON(b, jsonb []byte) []byte {
 	b = append(b, '\'')
 
 	return b
+}
+
+func (BaseDialect) AppendBool(b []byte, v bool) []byte {
+	return dialect.AppendBool(b, v)
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
In MSSQL it does not work for inserting and updating using boolean value. For using `BIT` to work we need to override `AppendBool` in dialect. 

Added in this pull-request an override for `AppendBool` in MSSQL dialect. Verified against Postgres and MSSQL - works as expected.

This fixes #695