### PR TITLE
fix: Updates error message

### DIFF
--- a/migrate/migrator.go
+++ b/migrate/migrator.go
@@ -380,7 +380,7 @@ func (m *Migrator) formattedTableName(db *bun.DB) string {
 
 func (m *Migrator) validate() error {
 	if len(m.ms) == 0 {
-		return errors.New("migrate: there are no any migrations")
+		return errors.New("migrate: there are no migrations")
 	}
 	return nil
 }


### PR DESCRIPTION
Cosmetic fix tbh.
The `migrator.validate()` method returned a weird looking error message: "migrate: there are no any migrations".

Updated to: "migrate: there are no migrations".