### PR TITLE
fix: prevent panic when use pg array with custom database type

### DIFF
--- a/internal/util.go
+++ b/internal/util.go
@@ -25,12 +25,12 @@ func MakeSliceNextElemFunc(v reflect.Value) func() reflect.Value {
 				if elem.IsNil() {
 					elem.Set(reflect.New(elemType))
 				}
-				return elem.Elem()
+				return elem
 			}
 
 			elem := reflect.New(elemType)
 			v.Set(reflect.Append(v, elem))
-			return elem.Elem()
+			return elem
 		}
 	}
 

--- a/util.go
+++ b/util.go
@@ -89,12 +89,12 @@ func makeSliceNextElemFunc(v reflect.Value) func() reflect.Value {
 				if elem.IsNil() {
 					elem.Set(reflect.New(elemType))
 				}
-				return elem.Elem()
+				return elem
 			}
 
 			elem := reflect.New(elemType)
 			v.Set(reflect.Append(v, elem))
-			return elem.Elem()
+			return elem
 		}
 	}
 


### PR DESCRIPTION
When define a model like

```go
type Table struct {
    bun.BaseModel 
    Id int `bun:"id,pk"`
    SomeValue []*CustomType `bun:",array,type:bytea[]"`
}
```

which uses pg Array with a custom type

```go
type CustomType struct {
    V []byte
}

func (t *CustomType) Value() (driver.Value, error)  {
    return t.V, nil
}

func (t *CustomType) Scan(src any) error {
  if src == nil {
    return nil
  }

  bytes, ok := src.([]byte)
  if !ok {
    return fmt.Errorf("unsupported data type: %T", src)
  }
 
  t.V = bytes
  return nil
}
```

A panic will happen in the previous version ("reflect: call of reflect.Value.IsNil on struct Value" from [PtrScanner - dest.IsNil](https://github.com/uptrace/bun/blob/0b38a1c902db03906b2c71807015916269269a12/schema/scan.go#L449)).

The PR fixes the panic.

I didn't write a Unit Test but I tested locally on my local machine. If you need a unit test and can tell me where I should add it, I will be a pleasure to help.