### PR TITLE
Allow string array in WithConnParams

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 - [Migrations](https://bun.uptrace.dev/guide/migrations.html).
 - [Soft deletes](https://bun.uptrace.dev/guide/soft-deletes.html).
 
-Resources:
+### Resources
 
 - [**Get started**](https://bun.uptrace.dev/guide/golang-orm.html)
 - [Examples](https://github.com/uptrace/bun/tree/master/example)
@@ -37,7 +37,11 @@ Resources:
 - [Reference](https://pkg.go.dev/github.com/uptrace/bun)
 - [Starter kit](https://github.com/go-bun/bun-starter-kit)
 
-Featured projects using Bun:
+### Tutorials
+
+Wrote a tutorial for Bun? Create a PR to add here and on [Bun](https://bun.uptrace.dev/) site.
+
+### Featured projects using Bun
 
 - [uptrace](https://github.com/uptrace/uptrace) - Distributed tracing and metrics.
 - [paralus](https://github.com/paralus/paralus) - All-in-one Kubernetes access manager.

--- a/driver/pgdriver/driver.go
+++ b/driver/pgdriver/driver.go
@@ -137,7 +137,8 @@ func newConn(ctx context.Context, cfg *Config) (*Conn, error) {
 	for k, v := range cfg.ConnParams {
 		if v != nil {
 			if vals, ok := v.([]string); ok {
-				_, err = cn.ExecContext(ctx, fmt.Sprintf("SET %s TO %s", k, strings.Join(vals, ",")), nil)
+				commaSep := "\"" + strings.Join(vals, "\", \"") + "\""
+				_, err = cn.ExecContext(ctx, fmt.Sprintf("SET %s TO %s", k, commaSep), nil)
 			} else {
 				_, err = cn.ExecContext(ctx, fmt.Sprintf("SET %s TO $1", k), []driver.NamedValue{
 					{Value: v},

--- a/driver/pgdriver/driver.go
+++ b/driver/pgdriver/driver.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 )
@@ -135,9 +136,13 @@ func newConn(ctx context.Context, cfg *Config) (*Conn, error) {
 
 	for k, v := range cfg.ConnParams {
 		if v != nil {
-			_, err = cn.ExecContext(ctx, fmt.Sprintf("SET %s TO $1", k), []driver.NamedValue{
-				{Value: v},
-			})
+			if vals, ok := v.([]string); ok {
+				_, err = cn.ExecContext(ctx, fmt.Sprintf("SET %s TO %s", k, strings.Join(vals, ",")), nil)
+			} else {
+				_, err = cn.ExecContext(ctx, fmt.Sprintf("SET %s TO $1", k), []driver.NamedValue{
+					{Value: v},
+				})
+			}
 		} else {
 			_, err = cn.ExecContext(ctx, fmt.Sprintf("SET %s TO DEFAULT", k), nil)
 		}

--- a/driver/pgdriver/driver_test.go
+++ b/driver/pgdriver/driver_test.go
@@ -260,7 +260,7 @@ func TestConnParamsArray(t *testing.T) {
 	db := sql.OpenDB(pgdriver.NewConnector(
 		pgdriver.WithDSN(dsn()),
 		pgdriver.WithConnParams(map[string]interface{}{
-			"search_path": []string{"foo", "bar"},
+			"search_path": []string{"foo baz", "bar"},
 		}),
 	))
 	defer db.Close()
@@ -268,7 +268,7 @@ func TestConnParamsArray(t *testing.T) {
 	var searchPath string
 	err := db.QueryRow("SHOW search_path").Scan(&searchPath)
 	require.NoError(t, err)
-	require.Equal(t, "foo, bar", searchPath)
+	require.Equal(t, "\"foo baz\", bar", searchPath)
 }
 
 func TestStatementTimeout(t *testing.T) {

--- a/driver/pgdriver/driver_test.go
+++ b/driver/pgdriver/driver_test.go
@@ -256,6 +256,21 @@ func TestConnParams(t *testing.T) {
 	require.Equal(t, "foo", searchPath)
 }
 
+func TestConnParamsArray(t *testing.T) {
+	db := sql.OpenDB(pgdriver.NewConnector(
+		pgdriver.WithDSN(dsn()),
+		pgdriver.WithConnParams(map[string]interface{}{
+			"search_path": []string{"foo", "bar"},
+		}),
+	))
+	defer db.Close()
+
+	var searchPath string
+	err := db.QueryRow("SHOW search_path").Scan(&searchPath)
+	require.NoError(t, err)
+	require.Equal(t, "foo, bar", searchPath)
+}
+
 func TestStatementTimeout(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
#611 
This PR allows multiple parameters to WithConnParams in the form of string slice
```
		pgdriver.WithConnParams(map[string]interface{}{
			"search_path": []string{"foo", "bar"},
		}),
```