### PR TITLE
Add support for inserting string values with unicode encoding for MSSQL Dialect

### DIFF
--- a/dialect/mssqldialect/dialect.go
+++ b/dialect/mssqldialect/dialect.go
@@ -127,6 +127,11 @@ func (*Dialect) AppendBool(b []byte, v bool) []byte {
 	return strconv.AppendUint(b, uint64(num), 10)
 }
 
+func (d *Dialect) AppendString(b []byte, s string) []byte {
+	b = append(b, 'N')
+	return d.BaseDialect.AppendString(b, s)
+}
+
 func (d *Dialect) DefaultVarcharLen() int {
 	return 255
 }


### PR DESCRIPTION
When you want to insert model to SQL Server databases with unicode string, you have to add `N` prefix to value in insert query.
This is a sample of query:

INSERT INTO TABLE ([Name]) VALUES (N'unicodechar')

I added the `N` prefix to the MSSQL Dialect append string method.