### PR TITLE
feat: prefix migration files with 1 upto 14 digits

### DIFF
--- a/migrate/migrations.go
+++ b/migrate/migrations.go
@@ -157,7 +157,7 @@ func migrationFile() string {
 	return ""
 }
 
-var fnameRE = regexp.MustCompile(`^(\d{14})_([0-9a-z_\-]+)\.`)
+var fnameRE = regexp.MustCompile(`^(\d{1,14})_([0-9a-z_\-]+)\.`)
 
 func extractMigrationName(fpath string) (string, string, error) {
 	fname := filepath.Base(fpath)


### PR DESCRIPTION
Slightly modified the migration file regexp to allow flexible width digit prefixes.
