### PR TITLE
fix: enable CompositeIn for MySQL

### DIFF
--- a/dialect/mysqldialect/dialect.go
+++ b/dialect/mysqldialect/dialect.go
@@ -45,7 +45,8 @@ func New() *Dialect {
 		feature.TableNotExists |
 		feature.InsertIgnore |
 		feature.InsertOnDuplicateKey |
-		feature.SelectExists
+		feature.SelectExists |
+		feature.CompositeIn
 	return d
 }
 


### PR DESCRIPTION
close: https://github.com/uptrace/bun/pull/632

MySQL support `IN` conditions with multiple fields.

See https://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#operator_in

So, I added `feature.CompositeIn` to the features.