### PR TITLE
feat(bunotel): add options for set otel providers of `bunotel.QueryHook`

### DIFF
--- a/extra/bunotel/option.go
+++ b/extra/bunotel/option.go
@@ -2,7 +2,9 @@ package bunotel
 
 import (
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type Option func(h *QueryHook)
@@ -28,5 +30,25 @@ func WithDBName(name string) Option {
 func WithFormattedQueries(format bool) Option {
 	return func(h *QueryHook) {
 		h.formatQueries = format
+	}
+}
+
+// WithTracerProvider returns an Option to use the TracerProvider when
+// creating a Tracer.
+func WithTracerProvider(tp trace.TracerProvider) Option {
+	return func(h *QueryHook) {
+		if tp != nil {
+			h.tracer = tp.Tracer("github.com/uptrace/bun")
+		}
+	}
+}
+
+// WithMeterProvider returns an Option to use the MeterProvider when
+// creating a Meter.
+func WithMeterProvider(mp metric.MeterProvider) Option {
+	return func(h *QueryHook) {
+		if mp != nil {
+			h.meter = mp.Meter("github.com/uptrace/bun")
+		}
 	}
 }


### PR DESCRIPTION
Allow using a specified TracerProvider and MeterProvider instead of the global ones.

- usage:
  ``` go
  db := bun.NewDB(sqldb, dialect, opts...)
  var tp trace.TracerProvider
  var mp metric.MeterProvider
  // initialize tracer and meter provider
  db.AddQueryHook(bunotel.NewQueryHook(bunotel.WithTracerProvider(tp), bunotel.WithMeterProvider(mp)))
  ```