### PR TITLE
fix "model does not have column" error

### DIFF
--- a/schema/table.go
+++ b/schema/table.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -806,18 +807,38 @@ func (t *Table) m2mRelation(field *Field) *Relation {
 	return rel
 }
 
-func (t *Table) inlineFields(field *Field, seen map[reflect.Type]struct{}) {
-	if seen == nil {
-		seen = map[reflect.Type]struct{}{t.Type: {}}
-	}
+type seenKey struct {
+	Table      reflect.Type
+	FieldIndex string
+}
 
-	if _, ok := seen[field.IndirectType]; ok {
-		return
+type seenMap map[seenKey]struct{}
+
+func NewSeenKey(table reflect.Type, fieldIndex []int) (key seenKey) {
+	key.Table = table
+	for _, index := range fieldIndex {
+		key.FieldIndex += strconv.Itoa(index) + "-"
 	}
-	seen[field.IndirectType] = struct{}{}
+	return key
+}
+
+func (s seenMap) Clone() seenMap {
+	t := make(seenMap)
+	for k, v := range s {
+		t[k] = v
+	}
+	return t
+}
+
+func (t *Table) inlineFields(field *Field, seen seenMap) {
+	if seen == nil {
+		seen = make(seenMap)
+	}
 
 	joinTable := t.dialect.Tables().Ref(field.IndirectType)
 	for _, f := range joinTable.allFields {
+		key := NewSeenKey(joinTable.Type, f.Index)
+
 		f = f.Clone()
 		f.GoName = field.GoName + "_" + f.GoName
 		f.Name = field.Name + "__" + f.Name
@@ -834,7 +855,9 @@ func (t *Table) inlineFields(field *Field, seen map[reflect.Type]struct{}) {
 			continue
 		}
 
-		if _, ok := seen[f.IndirectType]; !ok {
+		if _, ok := seen[key]; !ok {
+			seen = seen.Clone()
+			seen[key] = struct{}{}
 			t.inlineFields(f, seen)
 		}
 	}


### PR DESCRIPTION
The following type has two belongs-to fields with different names (BillingAddress and ShippingAddress) but with the same type (Address):

```
	type CompanyAddress struct {
		Id                int `bun:",pk"`
		CompanyId         int
		BillingAddressId  int
		BillingAddress    *Address `bun:"rel:belongs-to,join:billing_address_id=id"`
		ShippingAddressId int
		ShippingAddress   *Address `bun:"rel:belongs-to,join:shipping_address_id=id"`
	}
```

It causes this error when making a `SELECT` (see test case):

```
sql: Scan error on column index 7, name "company_address__shipping_address__id": bun: model=Company does not have column=company_address__shipping_address__id
```

I've attached a test case to demonstrate the problem.

This commit is an attempt to fix the bug. I've narrowed it down to the [Table.inlineFields](https://github.com/uptrace/bun/blob/dacffd2ac21ad0be76edb0425b806696728a29e1/schema/table.go#LL809C17-L809C29) method.

There is a `seen` map that saves which fields have already been visited to avoid an infinite loop in case of circular relations. In the case with two fields with different names but the same type (BillingAddress and ShippingAddress), the `seen` map prevents the `inlineFields` method to visit one of the two fields, which causes the error.

This is just one attempt to fix the bug, I'm happy to make changes if you think it should be fixes in another way.

(Another attempt by another contributor to fix this bug has been made in #849, original bug #847. This other PR doesn't have a test case, but fixes the problem elsewhere in the code, it might be interesting to compare the two different fixes.)