### PR TITLE
fix: Index hints are not working

### DIFF
--- a/internal/dbtest/testdata/snapshots/TestQuery-mariadb-132
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mariadb-132
@@ -1,1 +1,1 @@
-SELECT `story`.`id`, `story`.`name`, `story`.`user_id`, `user`.`id` AS `user__id`, `user`.`name` AS `user__name` FROM `stories` AS `story` LEFT JOIN `users` AS `user` ON (`user`.`id` = `story`.`user_id`) USE INDEX FOR JOIN (`ix1`)
+SELECT `story`.`id`, `story`.`name`, `story`.`user_id`, `user`.`id` AS `user__id`, `user`.`name` AS `user__name` FROM `stories` AS `story` USE INDEX FOR JOIN (`ix1`) LEFT JOIN `users` AS `user` ON (`user`.`id` = `story`.`user_id`)

--- a/internal/dbtest/testdata/snapshots/TestQuery-mariadb-137
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mariadb-137
@@ -1,1 +1,1 @@
-SELECT `story`.`id`, `story`.`name`, `story`.`user_id`, `user`.`id` AS `user__id`, `user`.`name` AS `user__name` FROM `stories` AS `story` LEFT JOIN `users` AS `user` ON (`user`.`id` = `story`.`user_id`) IGNORE INDEX FOR JOIN (`ix1`)
+SELECT `story`.`id`, `story`.`name`, `story`.`user_id`, `user`.`id` AS `user__id`, `user`.`name` AS `user__name` FROM `stories` AS `story` IGNORE INDEX FOR JOIN (`ix1`) LEFT JOIN `users` AS `user` ON (`user`.`id` = `story`.`user_id`)

--- a/internal/dbtest/testdata/snapshots/TestQuery-mariadb-142
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mariadb-142
@@ -1,1 +1,1 @@
-SELECT `story`.`id`, `story`.`name`, `story`.`user_id`, `user`.`id` AS `user__id`, `user`.`name` AS `user__name` FROM `stories` AS `story` LEFT JOIN `users` AS `user` ON (`user`.`id` = `story`.`user_id`) FORCE INDEX FOR JOIN (`ix1`)
+SELECT `story`.`id`, `story`.`name`, `story`.`user_id`, `user`.`id` AS `user__id`, `user`.`name` AS `user__name` FROM `stories` AS `story` FORCE INDEX FOR JOIN (`ix1`) LEFT JOIN `users` AS `user` ON (`user`.`id` = `story`.`user_id`)

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql5-132
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql5-132
@@ -1,1 +1,1 @@
-SELECT `story`.`id`, `story`.`name`, `story`.`user_id`, `user`.`id` AS `user__id`, `user`.`name` AS `user__name` FROM `stories` AS `story` LEFT JOIN `users` AS `user` ON (`user`.`id` = `story`.`user_id`) USE INDEX FOR JOIN (`ix1`)
+SELECT `story`.`id`, `story`.`name`, `story`.`user_id`, `user`.`id` AS `user__id`, `user`.`name` AS `user__name` FROM `stories` AS `story` USE INDEX FOR JOIN (`ix1`) LEFT JOIN `users` AS `user` ON (`user`.`id` = `story`.`user_id`)

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql5-137
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql5-137
@@ -1,1 +1,1 @@
-SELECT `story`.`id`, `story`.`name`, `story`.`user_id`, `user`.`id` AS `user__id`, `user`.`name` AS `user__name` FROM `stories` AS `story` LEFT JOIN `users` AS `user` ON (`user`.`id` = `story`.`user_id`) IGNORE INDEX FOR JOIN (`ix1`)
+SELECT `story`.`id`, `story`.`name`, `story`.`user_id`, `user`.`id` AS `user__id`, `user`.`name` AS `user__name` FROM `stories` AS `story` IGNORE INDEX FOR JOIN (`ix1`) LEFT JOIN `users` AS `user` ON (`user`.`id` = `story`.`user_id`)

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql5-142
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql5-142
@@ -1,1 +1,1 @@
-SELECT `story`.`id`, `story`.`name`, `story`.`user_id`, `user`.`id` AS `user__id`, `user`.`name` AS `user__name` FROM `stories` AS `story` LEFT JOIN `users` AS `user` ON (`user`.`id` = `story`.`user_id`) FORCE INDEX FOR JOIN (`ix1`)
+SELECT `story`.`id`, `story`.`name`, `story`.`user_id`, `user`.`id` AS `user__id`, `user`.`name` AS `user__name` FROM `stories` AS `story` FORCE INDEX FOR JOIN (`ix1`) LEFT JOIN `users` AS `user` ON (`user`.`id` = `story`.`user_id`)

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql8-132
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql8-132
@@ -1,1 +1,1 @@
-SELECT `story`.`id`, `story`.`name`, `story`.`user_id`, `user`.`id` AS `user__id`, `user`.`name` AS `user__name` FROM `stories` AS `story` LEFT JOIN `users` AS `user` ON (`user`.`id` = `story`.`user_id`) USE INDEX FOR JOIN (`ix1`)
+SELECT `story`.`id`, `story`.`name`, `story`.`user_id`, `user`.`id` AS `user__id`, `user`.`name` AS `user__name` FROM `stories` AS `story` USE INDEX FOR JOIN (`ix1`) LEFT JOIN `users` AS `user` ON (`user`.`id` = `story`.`user_id`)

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql8-137
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql8-137
@@ -1,1 +1,1 @@
-SELECT `story`.`id`, `story`.`name`, `story`.`user_id`, `user`.`id` AS `user__id`, `user`.`name` AS `user__name` FROM `stories` AS `story` LEFT JOIN `users` AS `user` ON (`user`.`id` = `story`.`user_id`) IGNORE INDEX FOR JOIN (`ix1`)
+SELECT `story`.`id`, `story`.`name`, `story`.`user_id`, `user`.`id` AS `user__id`, `user`.`name` AS `user__name` FROM `stories` AS `story` IGNORE INDEX FOR JOIN (`ix1`) LEFT JOIN `users` AS `user` ON (`user`.`id` = `story`.`user_id`)

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql8-142
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql8-142
@@ -1,1 +1,1 @@
-SELECT `story`.`id`, `story`.`name`, `story`.`user_id`, `user`.`id` AS `user__id`, `user`.`name` AS `user__name` FROM `stories` AS `story` LEFT JOIN `users` AS `user` ON (`user`.`id` = `story`.`user_id`) FORCE INDEX FOR JOIN (`ix1`)
+SELECT `story`.`id`, `story`.`name`, `story`.`user_id`, `user`.`id` AS `user__id`, `user`.`name` AS `user__name` FROM `stories` AS `story` FORCE INDEX FOR JOIN (`ix1`) LEFT JOIN `users` AS `user` ON (`user`.`id` = `story`.`user_id`)

--- a/query_select.go
+++ b/query_select.go
@@ -551,6 +551,11 @@ func (q *SelectQuery) appendQuery(
 		}
 	}
 
+	b, err = q.appendIndexHints(fmter, b)
+	if err != nil {
+		return nil, err
+	}
+
 	if err := q.forEachInlineRelJoin(func(j *relationJoin) error {
 		b = append(b, ' ')
 		b, err = j.appendHasOneJoin(fmter, b, q)
@@ -564,11 +569,6 @@ func (q *SelectQuery) appendQuery(
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	b, err = q.appendIndexHints(fmter, b)
-	if err != nil {
-		return nil, err
 	}
 
 	b, err = q.appendWhere(fmter, b, true)


### PR DESCRIPTION
Index hints have to be specified following a table name. 

See: https://dev.mysql.com/doc/refman/8.0/en/index-hints.html