### PR TITLE
Add validation in generating empty SET clause for StructModel

### DIFF
--- a/internal/dbtest/query_test.go
+++ b/internal/dbtest/query_test.go
@@ -989,6 +989,18 @@ func TestQuery(t *testing.T) {
 		func(db *bun.DB) schema.QueryAppender {
 			return db.NewUpdate().TableExpr("xxx").Set("foo = ?", bun.NullZero("")).Where("1")
 		},
+		func(db *bun.DB) schema.QueryAppender {
+			return db.NewUpdate().Model(new(Model)).OmitZero().WherePK()
+		},
+		func(db *bun.DB) schema.QueryAppender {
+			return db.NewUpdate().Model(&Model{Str: ""}).OmitZero().WherePK()
+		},
+		func(db *bun.DB) schema.QueryAppender {
+			return db.NewUpdate().Model(&Model{Str: ""}).WherePK()
+		},
+		func(db *bun.DB) schema.QueryAppender {
+			return db.NewUpdate().Model(&Model{42, ""}).OmitZero()
+		},
 	}
 
 	timeRE := regexp.MustCompile(`'2\d{3}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(\.\d+)?(\+\d{2}:\d{2})?'`)

--- a/internal/dbtest/testdata/snapshots/TestQuery-mariadb-159
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mariadb-159
@@ -1,0 +1,1 @@
+bun: empty SET clause is not allowed in the UPDATE query

--- a/internal/dbtest/testdata/snapshots/TestQuery-mariadb-160
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mariadb-160
@@ -1,0 +1,1 @@
+bun: empty SET clause is not allowed in the UPDATE query

--- a/internal/dbtest/testdata/snapshots/TestQuery-mariadb-161
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mariadb-161
@@ -1,0 +1,1 @@
+UPDATE `models` AS `model` SET `str` = '' WHERE (`model`.`id` = NULL)

--- a/internal/dbtest/testdata/snapshots/TestQuery-mariadb-162
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mariadb-162
@@ -1,0 +1,1 @@
+bun: empty SET clause is not allowed in the UPDATE query

--- a/internal/dbtest/testdata/snapshots/TestQuery-mariadb-87
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mariadb-87
@@ -1,1 +1,1 @@
-UPDATE `models` AS `model` SET  WHERE (`model`.`id` = 42)
+bun: empty SET clause is not allowed in the UPDATE query

--- a/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-159
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-159
@@ -1,0 +1,1 @@
+bun: empty SET clause is not allowed in the UPDATE query

--- a/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-160
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-160
@@ -1,0 +1,1 @@
+bun: empty SET clause is not allowed in the UPDATE query

--- a/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-161
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-161
@@ -1,0 +1,1 @@
+UPDATE "models" SET "str" = N'' WHERE ("id" = NULL)

--- a/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-162
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-162
@@ -1,0 +1,1 @@
+bun: empty SET clause is not allowed in the UPDATE query

--- a/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-87
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-87
@@ -1,1 +1,1 @@
-UPDATE "models" SET  WHERE ("id" = 42)
+bun: empty SET clause is not allowed in the UPDATE query

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql5-159
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql5-159
@@ -1,0 +1,1 @@
+bun: empty SET clause is not allowed in the UPDATE query

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql5-160
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql5-160
@@ -1,0 +1,1 @@
+bun: empty SET clause is not allowed in the UPDATE query

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql5-161
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql5-161
@@ -1,0 +1,1 @@
+UPDATE `models` AS `model` SET `str` = '' WHERE (`model`.`id` = NULL)

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql5-162
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql5-162
@@ -1,0 +1,1 @@
+bun: empty SET clause is not allowed in the UPDATE query

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql5-87
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql5-87
@@ -1,1 +1,1 @@
-UPDATE `models` AS `model` SET  WHERE (`model`.`id` = 42)
+bun: empty SET clause is not allowed in the UPDATE query

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql8-159
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql8-159
@@ -1,0 +1,1 @@
+bun: empty SET clause is not allowed in the UPDATE query

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql8-160
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql8-160
@@ -1,0 +1,1 @@
+bun: empty SET clause is not allowed in the UPDATE query

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql8-161
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql8-161
@@ -1,0 +1,1 @@
+UPDATE `models` AS `model` SET `str` = '' WHERE (`model`.`id` = NULL)

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql8-162
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql8-162
@@ -1,0 +1,1 @@
+bun: empty SET clause is not allowed in the UPDATE query

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql8-87
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql8-87
@@ -1,1 +1,1 @@
-UPDATE `models` AS `model` SET  WHERE (`model`.`id` = 42)
+bun: empty SET clause is not allowed in the UPDATE query

--- a/internal/dbtest/testdata/snapshots/TestQuery-pg-159
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pg-159
@@ -1,0 +1,1 @@
+bun: empty SET clause is not allowed in the UPDATE query

--- a/internal/dbtest/testdata/snapshots/TestQuery-pg-160
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pg-160
@@ -1,0 +1,1 @@
+bun: empty SET clause is not allowed in the UPDATE query

--- a/internal/dbtest/testdata/snapshots/TestQuery-pg-161
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pg-161
@@ -1,0 +1,1 @@
+UPDATE "models" AS "model" SET "str" = '' WHERE ("model"."id" = NULL)

--- a/internal/dbtest/testdata/snapshots/TestQuery-pg-162
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pg-162
@@ -1,0 +1,1 @@
+bun: empty SET clause is not allowed in the UPDATE query

--- a/internal/dbtest/testdata/snapshots/TestQuery-pg-87
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pg-87
@@ -1,1 +1,1 @@
-UPDATE "models" AS "model" SET  WHERE ("model"."id" = 42)
+bun: empty SET clause is not allowed in the UPDATE query

--- a/internal/dbtest/testdata/snapshots/TestQuery-pgx-159
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pgx-159
@@ -1,0 +1,1 @@
+bun: empty SET clause is not allowed in the UPDATE query

--- a/internal/dbtest/testdata/snapshots/TestQuery-pgx-160
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pgx-160
@@ -1,0 +1,1 @@
+bun: empty SET clause is not allowed in the UPDATE query

--- a/internal/dbtest/testdata/snapshots/TestQuery-pgx-161
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pgx-161
@@ -1,0 +1,1 @@
+UPDATE "models" AS "model" SET "str" = '' WHERE ("model"."id" = NULL)

--- a/internal/dbtest/testdata/snapshots/TestQuery-pgx-162
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pgx-162
@@ -1,0 +1,1 @@
+bun: empty SET clause is not allowed in the UPDATE query

--- a/internal/dbtest/testdata/snapshots/TestQuery-pgx-87
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pgx-87
@@ -1,1 +1,1 @@
-UPDATE "models" AS "model" SET  WHERE ("model"."id" = 42)
+bun: empty SET clause is not allowed in the UPDATE query

--- a/internal/dbtest/testdata/snapshots/TestQuery-sqlite-159
+++ b/internal/dbtest/testdata/snapshots/TestQuery-sqlite-159
@@ -1,0 +1,1 @@
+bun: empty SET clause is not allowed in the UPDATE query

--- a/internal/dbtest/testdata/snapshots/TestQuery-sqlite-160
+++ b/internal/dbtest/testdata/snapshots/TestQuery-sqlite-160
@@ -1,0 +1,1 @@
+bun: empty SET clause is not allowed in the UPDATE query

--- a/internal/dbtest/testdata/snapshots/TestQuery-sqlite-161
+++ b/internal/dbtest/testdata/snapshots/TestQuery-sqlite-161
@@ -1,0 +1,1 @@
+UPDATE "models" AS "model" SET "str" = '' WHERE ("model"."id" = NULL)

--- a/internal/dbtest/testdata/snapshots/TestQuery-sqlite-162
+++ b/internal/dbtest/testdata/snapshots/TestQuery-sqlite-162
@@ -1,0 +1,1 @@
+bun: empty SET clause is not allowed in the UPDATE query

--- a/internal/dbtest/testdata/snapshots/TestQuery-sqlite-87
+++ b/internal/dbtest/testdata/snapshots/TestQuery-sqlite-87
@@ -1,1 +1,1 @@
-UPDATE "models" AS "model" SET  WHERE ("model"."id" = 42)
+bun: empty SET clause is not allowed in the UPDATE query

--- a/query_update.go
+++ b/query_update.go
@@ -271,9 +271,17 @@ func (q *UpdateQuery) mustAppendSet(fmter schema.Formatter, b []byte) (_ []byte,
 
 	switch model := q.tableModel.(type) {
 	case *structTableModel:
+		pos := len(b)
 		b, err = q.appendSetStruct(fmter, b, model)
 		if err != nil {
 			return nil, err
+		}
+
+		// Validate if no values were appended after SET clause.
+		// e.g. UPDATE users SET WHERE id = 1
+		// See issues858
+		if len(b) == pos {
+			return nil, errors.New("bun: empty SET clause is not allowed in the UPDATE query")
 		}
 	case *sliceTableModel:
 		return nil, errors.New("bun: to bulk Update, use CTE and VALUES")


### PR DESCRIPTION
Attempt to fix the issues #858 & #684, where invalid `SET WHERE` statement is generated.
This only includes the check with struct model but not map. I can include map model if needed. 🙏 

Trying from a slightly different approach than the one suggested in the issue.

The test case mentioned in the issue: `db.NewUpdate().Model(new(Model)).WherePK()` should be a valid expression with `SET 'str' = ''` as `OmitZero()` is not set. It should set the field to ZeroValue.

Instead, test data snapshot `87` = `db.NewUpdate().Model(&Model{ID: 42}).OmitZero().WherePK()` should be the one invalid because no update field is provided while OmitZero is set.

Adding serval test cases as well.

