### PR TITLE
feat: export there are no migrations error

### DIFF
--- a/migrate/migrator.go
+++ b/migrate/migrator.go
@@ -12,6 +12,8 @@ import (
 	"github.com/uptrace/bun"
 )
 
+var ErrThereAreNoMigrations = errors.New("migrate: there are no migrations")
+
 type MigratorOption func(m *Migrator)
 
 func WithTableName(table string) MigratorOption {
@@ -378,7 +380,7 @@ func (m *Migrator) formattedTableName(db *bun.DB) string {
 
 func (m *Migrator) validate() error {
 	if len(m.ms) == 0 {
-		return errors.New("migrate: there are no migrations")
+		return ErrThereAreNoMigrations
 	}
 	return nil
 }


### PR DESCRIPTION
Hi 👋
I have implemented a CLI command to run migrations. In new projects, I might not have migrations from the start, and in such cases, my command fails.
I want to address this issue by exporting the validation error to be able to check it:
```go
_, err := migrator.Migrate(ctx)

if errors.Is(err, migrator.ErrThereAreNoMigrations) {
	return nil
}
```