### PR TITLE
feat: `dbfixture.New` to accept IDB interface

### DIFF
--- a/dbfixture/encoder.go
+++ b/dbfixture/encoder.go
@@ -15,11 +15,11 @@ type fixtureRows struct {
 }
 
 type Encoder struct {
-	db  *bun.DB
+	db  bun.IDB
 	enc *yaml.Encoder
 }
 
-func NewEncoder(db *bun.DB, w io.Writer) *Encoder {
+func NewEncoder(db bun.IDB, w io.Writer) *Encoder {
 	return &Encoder{
 		db:  db,
 		enc: yaml.NewEncoder(w),

--- a/dbfixture/fixture.go
+++ b/dbfixture/fixture.go
@@ -69,7 +69,7 @@ func WithBeforeInsert(fn BeforeInsertFunc) FixtureOption {
 }
 
 type Fixture struct {
-	db *bun.DB
+	db bun.IDB
 
 	recreateTables bool
 	truncateTables bool
@@ -81,7 +81,7 @@ type Fixture struct {
 	modelRows map[string]map[string]interface{}
 }
 
-func New(db *bun.DB, opts ...FixtureOption) *Fixture {
+func New(db bun.IDB, opts ...FixtureOption) *Fixture {
 	f := &Fixture{
 		db: db,
 


### PR DESCRIPTION
This PR addresses the limitation where the dbfixture.New function only accepts a pointer to `bun.DB`. Both `bun.DB` and `bun.TX` implement the `IDB` interface. By allowing `dbfixture.New` to accept the `IDB` interface, we provide more flexibility, especially during testing.

close https://github.com/uptrace/bun/issues/899