### PR TITLE
Cleanup test databases to avoid side-effects

### DIFF
--- a/internal/dbtest/bench_test.go
+++ b/internal/dbtest/bench_test.go
@@ -77,7 +77,7 @@ func benchEachDB(b *testing.B, f func(b *testing.B, db *bun.DB)) {
 			db.SetMaxOpenConns(64)
 			db.SetMaxIdleConns(64)
 
-			err := resetBenchSchema(db)
+			err := resetBenchSchema(b, db)
 			require.NoError(b, err)
 
 			b.ResetTimer()
@@ -86,10 +86,8 @@ func benchEachDB(b *testing.B, f func(b *testing.B, db *bun.DB)) {
 	}
 }
 
-func resetBenchSchema(db *bun.DB) error {
-	if err := db.ResetModel(ctx, (*Bench)(nil)); err != nil {
-		return err
-	}
+func resetBenchSchema(tb testing.TB, db *bun.DB) error {
+	mustResetModel(tb, ctx, db, (*Bench)(nil))
 
 	for i := 0; i < 1000; i++ {
 		bench := &Bench{

--- a/internal/dbtest/db_test.go
+++ b/internal/dbtest/db_test.go
@@ -679,10 +679,9 @@ func testRunInTx(t *testing.T, db *bun.DB) {
 		Count int64
 	}
 
-	err := db.ResetModel(ctx, (*Counter)(nil))
-	require.NoError(t, err)
+	mustResetModel(t, ctx, db, (*Counter)(nil))
 
-	_, err = db.NewInsert().Model(&Counter{Count: 0}).Exec(ctx)
+	_, err := db.NewInsert().Model(&Counter{Count: 0}).Exec(ctx)
 	require.NoError(t, err)
 
 	err = db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
@@ -723,15 +722,14 @@ func testJSONSpecialChars(t *testing.T, db *bun.DB) {
 
 	ctx := context.Background()
 
-	err := db.ResetModel(ctx, (*Model)(nil))
-	require.NoError(t, err)
+	mustResetModel(t, ctx, db, (*Model)(nil))
 
 	model := &Model{
 		Attrs: map[string]interface{}{
 			"hello": "\000world\nworld\u0000",
 		},
 	}
-	_, err = db.NewInsert().Model(model).Exec(ctx)
+	_, err := db.NewInsert().Model(model).Exec(ctx)
 	require.NoError(t, err)
 
 	model = new(Model)
@@ -757,11 +755,10 @@ func testJSONInterface(t *testing.T, db *bun.DB) {
 
 	ctx := context.Background()
 
-	err := db.ResetModel(ctx, (*Model)(nil))
-	require.NoError(t, err)
+	mustResetModel(t, ctx, db, (*Model)(nil))
 
 	model := new(Model)
-	_, err = db.NewInsert().Model(model).Exec(ctx)
+	_, err := db.NewInsert().Model(model).Exec(ctx)
 	require.NoError(t, err)
 
 	model = &Model{
@@ -801,11 +798,10 @@ func testJSONValuer(t *testing.T, db *bun.DB) {
 
 	ctx := context.Background()
 
-	err := db.ResetModel(ctx, (*Model)(nil))
-	require.NoError(t, err)
+	mustResetModel(t, ctx, db, (*Model)(nil))
 
 	model := new(Model)
-	_, err = db.NewInsert().Model(model).Exec(ctx)
+	_, err := db.NewInsert().Model(model).Exec(ctx)
 	require.NoError(t, err)
 
 	model2 := new(Model)
@@ -868,18 +864,14 @@ func testFKViolation(t *testing.T, db *bun.DB) {
 		require.NoError(t, err)
 	}
 
+	mustResetModel(t, ctx, db, (*User)(nil))
 	_, err := db.NewCreateTable().
-		Model((*User)(nil)).
-		IfNotExists().
-		Exec(ctx)
-	require.NoError(t, err)
-
-	_, err = db.NewCreateTable().
 		Model((*Deck)(nil)).
 		IfNotExists().
 		ForeignKey("(user_id) REFERENCES users (id) ON DELETE CASCADE").
 		Exec(ctx)
 	require.NoError(t, err)
+	mustDropTableOnCleanup(t, ctx, db, (*Deck)(nil))
 
 	// Empty deck should violate FK constraint.
 	_, err = db.NewInsert().Model(new(Deck)).Exec(ctx)
@@ -923,18 +915,14 @@ func testWithForeignKeysAndRules(t *testing.T, db *bun.DB) {
 		require.NoError(t, err)
 	}
 
+	mustResetModel(t, ctx, db, (*User)(nil))
 	_, err := db.NewCreateTable().
-		Model((*User)(nil)).
-		IfNotExists().
-		Exec(ctx)
-	require.NoError(t, err)
-
-	_, err = db.NewCreateTable().
 		Model((*Deck)(nil)).
 		IfNotExists().
 		WithForeignKeys().
 		Exec(ctx)
 	require.NoError(t, err)
+	mustDropTableOnCleanup(t, ctx, db, (*Deck)(nil))
 
 	// Empty deck should violate FK constraint.
 	_, err = db.NewInsert().Model(new(Deck)).Exec(ctx)
@@ -1011,18 +999,15 @@ func testWithForeignKeys(t *testing.T, db *bun.DB) {
 		require.NoError(t, err)
 	}
 
-	_, err := db.NewCreateTable().
-		Model((*User)(nil)).
-		IfNotExists().
-		Exec(ctx)
-	require.NoError(t, err)
+	mustResetModel(t, ctx, db, (*User)(nil))
 
-	_, err = db.NewCreateTable().
+	_, err := db.NewCreateTable().
 		Model((*Deck)(nil)).
 		IfNotExists().
 		WithForeignKeys().
 		Exec(ctx)
 	require.NoError(t, err)
+	mustDropTableOnCleanup(t, ctx, db, (*Deck)(nil))
 
 	// Empty deck should violate FK constraint.
 	_, err = db.NewInsert().Model(new(Deck)).Exec(ctx)
@@ -1109,14 +1094,13 @@ func testScanRawMessage(t *testing.T, db *bun.DB) {
 
 	ctx := context.Background()
 
-	err := db.ResetModel(ctx, (*Model)(nil))
-	require.NoError(t, err)
+	mustResetModel(t, ctx, db, (*Model)(nil))
 
 	models := []Model{
 		{Value: json.RawMessage(`"hello"`)},
 		{Value: json.RawMessage(`"world"`)},
 	}
-	_, err = db.NewInsert().Model(&models).Exec(ctx)
+	_, err := db.NewInsert().Model(&models).Exec(ctx)
 	require.NoError(t, err)
 
 	var models1 []Model
@@ -1139,8 +1123,7 @@ func testPointers(t *testing.T, db *bun.DB) {
 	ctx := context.Background()
 
 	for _, id := range []int64{-1, 0, 1} {
-		err := db.ResetModel(ctx, (*Model)(nil))
-		require.NoError(t, err)
+		mustResetModel(t, ctx, db, (*Model)(nil))
 
 		var model Model
 		if id >= 0 {
@@ -1150,7 +1133,7 @@ func testPointers(t *testing.T, db *bun.DB) {
 
 		}
 
-		_, err = db.NewInsert().Model(&model).Exec(ctx)
+		_, err := db.NewInsert().Model(&model).Exec(ctx)
 		require.NoError(t, err)
 
 		var model2 Model
@@ -1195,11 +1178,9 @@ func testBinaryData(t *testing.T, db *bun.DB) {
 	}
 
 	ctx := context.Background()
+	mustResetModel(t, ctx, db, (*Model)(nil))
 
-	err := db.ResetModel(ctx, (*Model)(nil))
-	require.NoError(t, err)
-
-	_, err = db.NewInsert().Model(&Model{Data: []byte("hello")}).Exec(ctx)
+	_, err := db.NewInsert().Model(&Model{Data: []byte("hello")}).Exec(ctx)
 	require.NoError(t, err)
 
 	var model Model
@@ -1219,13 +1200,11 @@ func testUpsert(t *testing.T, db *bun.DB) {
 	}
 
 	ctx := context.Background()
-
-	err := db.ResetModel(ctx, (*Model)(nil))
-	require.NoError(t, err)
+	mustResetModel(t, ctx, db, (*Model)(nil))
 
 	model := &Model{ID: 1, Str: "hello"}
 
-	_, err = db.NewInsert().Model(model).Exec(ctx)
+	_, err := db.NewInsert().Model(model).Exec(ctx)
 	require.NoError(t, err)
 
 	model.Str = "world"
@@ -1256,13 +1235,11 @@ func testMultiUpdate(t *testing.T, db *bun.DB) {
 	}
 
 	ctx := context.Background()
-
-	err := db.ResetModel(ctx, (*Model)(nil))
-	require.NoError(t, err)
+	mustResetModel(t, ctx, db, (*Model)(nil))
 
 	model := &Model{ID: 1, Str: "hello"}
 
-	_, err = db.NewInsert().Model(model).Exec(ctx)
+	_, err := db.NewInsert().Model(model).Exec(ctx)
 	require.NoError(t, err)
 
 	selq := db.NewSelect().Model(new(Model))
@@ -1285,15 +1262,13 @@ func testUpdateWithSkipupdateTag(t *testing.T, db *bun.DB) {
 	}
 
 	ctx := context.Background()
-
-	err := db.ResetModel(ctx, (*Model)(nil))
-	require.NoError(t, err)
+	mustResetModel(t, ctx, db, (*Model)(nil))
 
 	createdAt := time.Now().Truncate(time.Minute).UTC()
 
 	model := &Model{ID: 1, Name: "foo", CreatedAt: createdAt}
 
-	_, err = db.NewInsert().Model(model).Exec(ctx)
+	_, err := db.NewInsert().Model(model).Exec(ctx)
 	require.NoError(t, err)
 	require.NotZero(t, model.CreatedAt)
 
@@ -1326,9 +1301,7 @@ func testScanAndCount(t *testing.T, db *bun.DB) {
 	}
 
 	ctx := context.Background()
-
-	err := db.ResetModel(ctx, (*Model)(nil))
-	require.NoError(t, err)
+	mustResetModel(t, ctx, db, (*Model)(nil))
 
 	t.Run("tx", func(t *testing.T) {
 		for i := 0; i < 100; i++ {
@@ -1348,7 +1321,7 @@ func testScanAndCount(t *testing.T, db *bun.DB) {
 			{Str: "str1"},
 			{Str: "str2"},
 		}
-		_, err = db.NewInsert().Model(&src).Exec(ctx)
+		_, err := db.NewInsert().Model(&src).Exec(ctx)
 		require.NoError(t, err)
 
 		var dest []Model
@@ -1376,9 +1349,7 @@ func testEmbedModelValue(t *testing.T, db *bun.DB) {
 	}
 
 	ctx := context.Background()
-
-	err := db.ResetModel(ctx, (*Model)(nil))
-	require.NoError(t, err)
+	mustResetModel(t, ctx, db, (*Model)(nil))
 
 	m1 := &Model{
 		X: Embed{
@@ -1406,7 +1377,7 @@ func testEmbedModelValue(t *testing.T, db *bun.DB) {
 			},
 		},
 	}
-	_, err = db.NewInsert().Model(m1).Exec(ctx)
+	_, err := db.NewInsert().Model(m1).Exec(ctx)
 	require.NoError(t, err)
 
 	var m2 Model
@@ -1432,9 +1403,7 @@ func testEmbedModelPointer(t *testing.T, db *bun.DB) {
 	}
 
 	ctx := context.Background()
-
-	err := db.ResetModel(ctx, (*Model)(nil))
-	require.NoError(t, err)
+	mustResetModel(t, ctx, db, (*Model)(nil))
 
 	m1 := &Model{
 		X: &Embed{
@@ -1462,7 +1431,7 @@ func testEmbedModelPointer(t *testing.T, db *bun.DB) {
 			},
 		},
 	}
-	_, err = db.NewInsert().Model(m1).Exec(ctx)
+	_, err := db.NewInsert().Model(m1).Exec(ctx)
 	require.NoError(t, err)
 
 	var m2 Model
@@ -1478,14 +1447,12 @@ func testEmbedTypeField(t *testing.T, db *bun.DB) {
 	}
 
 	ctx := context.Background()
-
-	err := db.ResetModel(ctx, (*Model)(nil))
-	require.NoError(t, err)
+	mustResetModel(t, ctx, db, (*Model)(nil))
 
 	m1 := &Model{
 		Embed: Embed("foo"),
 	}
-	_, err = db.NewInsert().Model(m1).Exec(ctx)
+	_, err := db.NewInsert().Model(m1).Exec(ctx)
 	require.NoError(t, err)
 
 	var m2 Model
@@ -1508,12 +1475,10 @@ func testJSONMarshaler(t *testing.T, db *bun.DB) {
 	}
 
 	ctx := context.Background()
-
-	err := db.ResetModel(ctx, (*Model)(nil))
-	require.NoError(t, err)
+	mustResetModel(t, ctx, db, (*Model)(nil))
 
 	m1 := &Model{Field: new(JSONField)}
-	_, err = db.NewInsert().Model(m1).Exec(ctx)
+	_, err := db.NewInsert().Model(m1).Exec(ctx)
 	require.NoError(t, err)
 
 	var m2 Model
@@ -1538,11 +1503,9 @@ func testNilDriverValue(t *testing.T, db *bun.DB) {
 	}
 
 	ctx := context.Background()
+	mustResetModel(t, ctx, db, (*Model)(nil))
 
-	err := db.ResetModel(ctx, (*Model)(nil))
-	require.NoError(t, err)
-
-	_, err = db.NewInsert().Model(&Model{}).Exec(ctx)
+	_, err := db.NewInsert().Model(&Model{}).Exec(ctx)
 	require.NoError(t, err)
 
 	_, err = db.NewInsert().Model(&Model{Value: &DriverValue{s: "hello"}}).Exec(ctx)
@@ -1554,10 +1517,9 @@ func testRunInTxAndSavepoint(t *testing.T, db *bun.DB) {
 		Count int64
 	}
 
-	err := db.ResetModel(ctx, (*Counter)(nil))
-	require.NoError(t, err)
+	mustResetModel(t, ctx, db, (*Counter)(nil))
 
-	_, err = db.NewInsert().Model(&Counter{Count: 0}).Exec(ctx)
+	_, err := db.NewInsert().Model(&Counter{Count: 0}).Exec(ctx)
 	require.NoError(t, err)
 
 	err = db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
@@ -1662,12 +1624,10 @@ func testDriverValuerReturnsItself(t *testing.T, db *bun.DB) {
 	}
 
 	ctx := context.Background()
-
-	err := db.ResetModel(ctx, (*Model)(nil))
-	require.NoError(t, err)
+	mustResetModel(t, ctx, db, (*Model)(nil))
 
 	model := &Model{Value: expectedValue}
-	_, err = db.NewInsert().Model(model).Exec(ctx)
+	_, err := db.NewInsert().Model(model).Exec(ctx)
 	require.Error(t, err)
 }
 
@@ -1678,13 +1638,27 @@ func testNoPanicWhenReturningNullColumns(t *testing.T, db *bun.DB) {
 	}
 
 	ctx := context.Background()
-
-	err := db.ResetModel(ctx, (*Model)(nil))
-	require.NoError(t, err)
+	mustResetModel(t, ctx, db, (*Model)(nil))
 
 	modelSlice := []*Model{{Value: "boom"}}
 
 	require.NotPanics(t, func() {
 		db.NewInsert().Model(&modelSlice).Exec(ctx)
+	})
+}
+
+func mustResetModel(tb testing.TB, ctx context.Context, db *bun.DB, models ...interface{}) {
+	err := db.ResetModel(ctx, models...)
+	require.NoError(tb, err, "must reset model")
+	mustDropTableOnCleanup(tb, ctx, db, models...)
+}
+
+func mustDropTableOnCleanup(tb testing.TB, ctx context.Context, db *bun.DB, models ...interface{}) {
+	tb.Cleanup(func() {
+		for _, model := range models {
+			drop := db.NewDropTable().IfExists().Model(model)
+			_, err := drop.Exec(ctx)
+			require.NoError(tb, err, "must drop table: %q", drop.GetTableName())
+		}
 	})
 }

--- a/internal/dbtest/model_hook_test.go
+++ b/internal/dbtest/model_hook_test.go
@@ -39,8 +39,7 @@ func TestModelHook(t *testing.T) {
 }
 
 func testModelHook(t *testing.T, dbName string, db *bun.DB) {
-	err := db.ResetModel(ctx, (*ModelHookTest)(nil))
-	require.NoError(t, err)
+	mustResetModel(t, ctx, db, (*ModelHookTest)(nil))
 
 	{
 		hook := &ModelHookTest{ID: 1}

--- a/internal/dbtest/mssql_test.go
+++ b/internal/dbtest/mssql_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestMssqlMerge(t *testing.T) {
 	db := mssql2019(t)
-	defer db.Close()
+	t.Cleanup(func() { db.Close() })
 
 	type Model struct {
 		ID int64 `bun:",pk,autoincrement"`
@@ -17,10 +17,9 @@ func TestMssqlMerge(t *testing.T) {
 		Value string
 	}
 
-	err := db.ResetModel(ctx, (*Model)(nil))
-	require.NoError(t, err)
+	mustResetModel(t, ctx, db, (*Model)(nil))
 
-	_, err = db.NewInsert().Model(&Model{Name: "A", Value: "hello"}).Exec(ctx)
+	_, err := db.NewInsert().Model(&Model{Name: "A", Value: "hello"}).Exec(ctx)
 	require.NoError(t, err)
 
 	newModels := []*Model{

--- a/internal/dbtest/orm_test.go
+++ b/internal/dbtest/orm_test.go
@@ -355,14 +355,13 @@ func testRelationBelongsToSelf(t *testing.T, db *bun.DB) {
 		Model   *Model `bun:"rel:belongs-to"`
 	}
 
-	err := db.ResetModel(ctx, (*Model)(nil))
-	require.NoError(t, err)
+	mustResetModel(t, ctx, db, (*Model)(nil))
 
 	models := []Model{
 		{ID: 1},
 		{ID: 2, ModelID: 1},
 	}
-	_, err = db.NewInsert().Model(&models).Exec(ctx)
+	_, err := db.NewInsert().Model(&models).Exec(ctx)
 	require.NoError(t, err)
 
 	models = nil
@@ -396,15 +395,13 @@ func testM2MRelationExcludeColumn(t *testing.T, db *bun.DB) {
 	}
 
 	db.RegisterModel((*OrderToItem)(nil))
-
-	err := db.ResetModel(ctx, (*Order)(nil), (*Item)(nil), (*OrderToItem)(nil))
-	require.NoError(t, err)
+	mustResetModel(t, ctx, db, (*Order)(nil), (*Item)(nil), (*OrderToItem)(nil))
 
 	items := []Item{
 		{ID: 1, CreatedAt: time.Unix(1, 0), UpdatedAt: time.Unix(1, 0)},
 		{ID: 2, CreatedAt: time.Unix(2, 0), UpdatedAt: time.Unix(1, 0)},
 	}
-	_, err = db.NewInsert().Model(&items).Exec(ctx)
+	_, err := db.NewInsert().Model(&items).Exec(ctx)
 	require.NoError(t, err)
 
 	orders := []Order{
@@ -574,11 +571,7 @@ func createTestSchema(t *testing.T, db *bun.DB) {
 		(*Employee)(nil),
 	}
 	for _, model := range models {
-		_, err := db.NewDropTable().Model(model).IfExists().Exec(ctx)
-		require.NoError(t, err)
-
-		_, err = db.NewCreateTable().Model(model).Exec(ctx)
-		require.NoError(t, err)
+		mustResetModel(t, ctx, db, model)
 	}
 }
 

--- a/internal/dbtest/soft_delete_test.go
+++ b/internal/dbtest/soft_delete_test.go
@@ -39,11 +39,9 @@ type Video struct {
 
 func testSoftDeleteNilModel(t *testing.T, db *bun.DB) {
 	ctx := context.Background()
+	mustResetModel(t, ctx, db, (*Video)(nil))
 
-	err := db.ResetModel(ctx, (*Video)(nil))
-	require.NoError(t, err)
-
-	_, err = db.NewDelete().Model((*Video)(nil)).Where("1 = 1").Exec(ctx)
+	_, err := db.NewDelete().Model((*Video)(nil)).Where("1 = 1").Exec(ctx)
 	require.NoError(t, err)
 
 	_, err = db.NewDelete().Model((*Video)(nil)).Where("1 = 1").ForceDelete().Exec(ctx)
@@ -52,14 +50,12 @@ func testSoftDeleteNilModel(t *testing.T, db *bun.DB) {
 
 func testSoftDeleteAPI(t *testing.T, db *bun.DB) {
 	ctx := context.Background()
-
-	err := db.ResetModel(ctx, (*Video)(nil))
-	require.NoError(t, err)
+	mustResetModel(t, ctx, db, (*Video)(nil))
 
 	video1 := &Video{
 		ID: 1,
 	}
-	_, err = db.NewInsert().Model(video1).Exec(ctx)
+	_, err := db.NewInsert().Model(video1).Exec(ctx)
 	require.NoError(t, err)
 
 	// Count visible videos.
@@ -107,9 +103,7 @@ func testSoftDeleteAPI(t *testing.T, db *bun.DB) {
 
 func testSoftDeleteForce(t *testing.T, db *bun.DB) {
 	ctx := context.Background()
-
-	err := db.ResetModel(ctx, (*Video)(nil))
-	require.NoError(t, err)
+	mustResetModel(t, ctx, db, (*Video)(nil))
 
 	videos := []Video{
 		{Name: "video1"},
@@ -117,7 +111,7 @@ func testSoftDeleteForce(t *testing.T, db *bun.DB) {
 		{Name: "video3"},
 	}
 
-	_, err = db.NewInsert().Model(&videos).Exec(ctx)
+	_, err := db.NewInsert().Model(&videos).Exec(ctx)
 	require.NoError(t, err)
 
 	// Force delete video1.
@@ -160,15 +154,13 @@ func testSoftDeleteForce(t *testing.T, db *bun.DB) {
 
 func testSoftDeleteBulk(t *testing.T, db *bun.DB) {
 	ctx := context.Background()
-
-	err := db.ResetModel(ctx, (*Video)(nil))
-	require.NoError(t, err)
+	mustResetModel(t, ctx, db, (*Video)(nil))
 
 	videos := []Video{
 		{Name: "video1"},
 		{Name: "video2"},
 	}
-	_, err = db.NewInsert().Model(&videos).Exec(ctx)
+	_, err := db.NewInsert().Model(&videos).Exec(ctx)
 	require.NoError(t, err)
 
 	if db.Dialect().Features().Has(feature.CTE) {


### PR DESCRIPTION
While working on #926 I noticed that many tests did not properly tear down the database schema they create, which results in side-effects to other tests.

Existing tests were not affected,  but the ones I wrote for the other PR were, as they rely on having a clean schema.
In general, I think leaving no side-effects is a good unit test practice.