### PR TITLE
update: *DB and Tx implement tha same interface "QueryExecuter"

### DIFF
--- a/db.go
+++ b/db.go
@@ -32,6 +32,31 @@ func WithDiscardUnknownColumns() DBOption {
 	}
 }
 
+// *DB & Tx implemenet the same interface
+type QueryExecuter interface {
+	NewValues(interface{}) *ValuesQuery
+	NewMerge() *MergeQuery
+	NewSelect() *SelectQuery
+	NewInsert() *InsertQuery
+	NewUpdate() *UpdateQuery
+	NewDelete() *DeleteQuery
+	NewRaw(string, ...interface{}) *RawQuery
+	NewCreateTable() *CreateTableQuery
+	NewDropTable() *DropTableQuery
+	NewCreateIndex() *CreateIndexQuery
+	NewDropIndex() *DropIndexQuery
+	NewTruncateTable() *TruncateTableQuery
+	NewAddColumn() *AddColumnQuery
+	NewDropColumn() *DropColumnQuery
+	Dialect() schema.Dialect
+	Query(string, ...interface{}) (*sql.Rows, error)
+	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
+	QueryRow(string, ...interface{}) *sql.Row
+	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	Exec(string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+}
+
 type DB struct {
 	*sql.DB
 


### PR DESCRIPTION

@max107 

Hello! I just wanted to make one suggestion, and I'm a PR.

*DB and Tx to implement a common interface "QueryExecuter". Otherwise, if we want to handle transactions in the usecase layer in clean architecture, etc., the usecase must directly hold *bun.

*DB and bun.Tx to implement a common interface, it would be easier to use transaction processing in the usecase layer by using context. 

For a concrete example, look at the following sample code(For the sake of simplification, usecase and repository are not interfaces but structs.)

repository layer
```go
type ( 
  DBExecuter interface {
      GetDB(context.Context) bun.QueryExecuter
  }
  dbExecuterChild struct {
      db *bun.DB
  }
)
var txKey struct{}

func DoInTx[T any](ctx context.Context, db *bun.DB, f func(context.Context)(T,error)){
  var result T
  tx, err := db.BeginTx(ctx)
  if err != nil {
    return T, err
  }
  ctx = context.WithValue(ctx, txKey, tx)
  result, err = f(ctx)
  if err != nil {
    if err := tx.RollBack(); err != nil {
      return result, err
    }
    return result, err
  }
  if err := tx.Commit(); err != nil {
    return result, err
  }
  return result, nil
}

func NewDBExecuter(db *bun.DB) DBExecuter {
    return &dbExecuterChild{db: db}
}

func(de *dbExecuterChild) GetDB(ctx context.Context) bun.QueryExecuter {
  tx, ok := ctx.Value(txKey).(bun.Tx)
  if ok {
       return tx
  }
  return de.db
}

type (
  RepositoryA struct {
      db DBExecuter
  } 
  SampleData struct {
    ID int64 `bun:"id"`
    Name string `bun:"name"`
  }
)
func (r *RepositoryA) GetDB() bun.QueryExecuter {
  return r.db
}
func (r *RepositoryA) GetData(ctx context.Context, model SampleData) (SampleData, error){
    if err := r.db.GetDB(ctx).NewSelect().Model(&model).Scan(ctx); err != nil {
        return nil, err
    }
    return model, nil
}
func (r *RepositoryA) InsertData(ctx context.Context, model SampleData)  error {
    return r.db.GetDB(ctx).NewInsert().Model(&model).Exec(ctx)
}

```

usecase layer
```go
type (
  UseCase struct {
      repository repository.RepositoryA
  }
)

func(u *UseCase) GetData(ctx context.Context)( repositry.SampleData, error){
  result, err := u.repository.GetData(ctx, repositry.SampleData{})
  ...
}
func(u *UseCase) InsertData(ctx context.Context) error {
  return repository.DoInTx(ctx, u.repository.GetDB(), f func(ctx context.Context)(repositry.SampleData ,error)){
    result, err := u.repositoryA.InsertData(ctx, repositry.SampleData{ID: 1, Name: "sample"})
    ...
    return nil
  }
}
```

If you have any questions about something you are not sure about, please ask!