### PR TITLE
Allow overiding of `Warn` and `Deprecated` loggers

### DIFF
--- a/bun.go
+++ b/bun.go
@@ -72,7 +72,7 @@ type AfterDropTableHook interface {
 
 // SetLogger overwriters default Bun logger.
 func SetLogger(logger internal.Logging) {
-	internal.Logger = logger
+	internal.SetLogger(logger)
 }
 
 func In(slice interface{}) schema.QueryAppender {

--- a/internal/logger.go
+++ b/internal/logger.go
@@ -6,12 +6,24 @@ import (
 	"os"
 )
 
-var Warn = log.New(os.Stderr, "WARN: bun: ", log.LstdFlags)
-
-var Deprecated = log.New(os.Stderr, "DEPRECATED: bun: ", log.LstdFlags)
-
 type Logging interface {
 	Printf(format string, v ...interface{})
+}
+
+var defaultLogger = log.New(os.Stderr, "", log.LstdFlags)
+
+var Logger Logging = &logger{
+	log: defaultLogger,
+}
+
+var Warn = &wrapper{
+	prefix: "WARN: bun: ",
+	logger: Logger,
+}
+
+var Deprecated = &wrapper{
+	prefix: "DEPRECATED: bun: ",
+	logger: Logger,
 }
 
 type logger struct {
@@ -22,6 +34,21 @@ func (l *logger) Printf(format string, v ...interface{}) {
 	_ = l.log.Output(2, fmt.Sprintf(format, v...))
 }
 
-var Logger Logging = &logger{
-	log: log.New(os.Stderr, "bun: ", log.LstdFlags|log.Lshortfile),
+type wrapper struct {
+	prefix string
+	logger Logging
+}
+
+func (w *wrapper) Printf(format string, v ...interface{}) {
+	w.logger.Printf(w.prefix+format, v...)
+}
+
+func SetLogger(newLogger Logging) {
+	if newLogger == nil {
+		Logger = &logger{log: defaultLogger}
+	} else {
+		Logger = newLogger
+	}
+	Warn.logger = Logger
+	Deprecated.logger = Logger
 }


### PR DESCRIPTION
Currently,  `internal.Warn.Printf()` and `internal.Deprecate.Printf()` have numerous calls but no way of overriding them with your own logger.