### PR TITLE
enable SNI

### DIFF
--- a/driver/pgdriver/config.go
+++ b/driver/pgdriver/config.go
@@ -269,6 +269,10 @@ func parseDSN(dsn string) ([]Option, error) {
 		case "require":
 			if sslRootCert == "" {
 				tlsConfig.InsecureSkipVerify = true
+				tlsConfig.ServerName = u.Host
+				if host, _, err := net.SplitHostPort(u.Host); err == nil {
+					tlsConfig.ServerName = host
+				}
 				break
 			}
 			// For backwards compatibility reasons, in the presence of `sslrootcert`,
@@ -283,6 +287,10 @@ func parseDSN(dsn string) ([]Option, error) {
 			// (verify chain, but skip server name).
 			// See https://github.com/golang/go/issues/21971 .
 			tlsConfig.InsecureSkipVerify = true
+			tlsConfig.ServerName = u.Host
+			if host, _, err := net.SplitHostPort(u.Host); err == nil {
+				tlsConfig.ServerName = host
+			}
 			tlsConfig.VerifyPeerCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 				certs := make([]*x509.Certificate, 0, len(rawCerts))
 				for _, rawCert := range rawCerts {


### PR DESCRIPTION
Adding the ServerName config allows TLS to include the ServerNameIdentification (SNI) extension. We use this at Neon to determine which database endpoint to connect to: https://neon.tech/docs/connect/connection-errors#the-endpoint-id-is-not-specified

I have tested that this works for `sslmode=require`, but I need to still confirm that this doesn't break the insecure modes from being insecure