### PR TITLE
fix(table): allow alt annotation

### DIFF
--- a/schema/table.go
+++ b/schema/table.go
@@ -913,7 +913,7 @@ func isKnownTableOption(name string) bool {
 func isKnownFieldOption(name string) bool {
 	switch name {
 	case "column",
-		"alias",
+		"alt",
 		"type",
 		"array",
 		"hstore",

--- a/schema/table_test.go
+++ b/schema/table_test.go
@@ -204,4 +204,23 @@ func TestTable(t *testing.T) {
 			require.Equal(t, []int{2, 0}, id.Index)
 		}
 	})
+
+	t.Run("alternative name", func(t *testing.T) {
+		type ModelTest struct {
+			Model
+			Foo string `bun:"alt:alt_name"`
+		}
+
+		table := tables.Get(reflect.TypeOf((*ModelTest)(nil)))
+
+		foo, ok := table.FieldMap["foo"]
+		require.True(t, ok)
+		require.Equal(t, []int{1}, foo.Index)
+
+		foo2, ok := table.FieldMap["alt_name"]
+		require.True(t, ok)
+		require.Equal(t, []int{1}, foo2.Index)
+
+		require.Equal(t, table.FieldMap["foo"].SQLName, table.FieldMap["alt_name"].SQLName)
+	})
 }


### PR DESCRIPTION
fix #954 by setting/asserting the alternative field name option as _alt_ instead of "alias" (in fields options) which was probably a typo in the first place, i also added a corresponding test