### PR TITLE
fix: transactional migration file extension

### DIFF
--- a/migrate/migrator.go
+++ b/migrate/migrator.go
@@ -274,12 +274,12 @@ func (m *Migrator) CreateTxSQLMigrations(ctx context.Context, name string) ([]*M
 		return nil, err
 	}
 
-	up, err := m.createSQL(ctx, name+".up.tx.sql", true)
+	up, err := m.createSQL(ctx, name+".tx.up.sql", true)
 	if err != nil {
 		return nil, err
 	}
 
-	down, err := m.createSQL(ctx, name+".down.tx.sql", true)
+	down, err := m.createSQL(ctx, name+".tx.down.sql", true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The migrations wouldn't run unless formatted like `tx.up.sql`, which is the correct extension according to the docs: https://bun.uptrace.dev/guide/migrations.html#sql-based-migrations