### PR TITLE
add NewMerge method to IDB

### DIFF
--- a/query_base.go
+++ b/query_base.go
@@ -51,6 +51,7 @@ type IDB interface {
 	NewInsert() *InsertQuery
 	NewUpdate() *UpdateQuery
 	NewDelete() *DeleteQuery
+	NewMerge() *MergeQuery
 	NewRaw(query string, args ...interface{}) *RawQuery
 	NewCreateTable() *CreateTableQuery
 	NewDropTable() *DropTableQuery


### PR DESCRIPTION
This adds the `NewMerge` method to the `IDB` interface.