### PR TITLE
feat: add ModelTableExpr to TruncateTableQuery

### DIFF
--- a/migrate/migrator.go
+++ b/migrate/migrator.go
@@ -362,7 +362,9 @@ func (m *Migrator) MarkUnapplied(ctx context.Context, migration *Migration) erro
 }
 
 func (m *Migrator) TruncateTable(ctx context.Context) error {
-	_, err := m.db.NewTruncateTable().TableExpr(m.table).Exec(ctx)
+	_, err := m.db.NewTruncateTable().
+		ModelTableExpr(m.table).
+		Exec(ctx)
 	return err
 }
 

--- a/migrate/migrator.go
+++ b/migrate/migrator.go
@@ -363,6 +363,7 @@ func (m *Migrator) MarkUnapplied(ctx context.Context, migration *Migration) erro
 
 func (m *Migrator) TruncateTable(ctx context.Context) error {
 	_, err := m.db.NewTruncateTable().
+		Model((*Migration)(nil)).
 		ModelTableExpr(m.table).
 		Exec(ctx)
 	return err

--- a/query_table_truncate.go
+++ b/query_table_truncate.go
@@ -57,6 +57,11 @@ func (q *TruncateTableQuery) TableExpr(query string, args ...interface{}) *Trunc
 	return q
 }
 
+func (q *TruncateTableQuery) ModelTableExpr(query string, args ...interface{}) *TruncateTableQuery {
+	q.modelTableName = schema.SafeQuery(query, args)
+	return q
+}
+
 //------------------------------------------------------------------------------
 
 func (q *TruncateTableQuery) ContinueIdentity() *TruncateTableQuery {


### PR DESCRIPTION
This PR fixes #960.

I implemented a ModelTableExpr method in TruncateTableQuery as well, referring to CreateTableQuery, etc.

The [Document](https://bun.uptrace.dev/guide/query-truncate-table.html#api) stated that ModelTableExpr can be used, but it is not implemented actually, so I made this modification.

I would appreciate it if you check it out!