### PR TITLE
Fix embedded field detection

### DIFF
--- a/schema/table.go
+++ b/schema/table.go
@@ -207,7 +207,7 @@ func (t *Table) processFields(
 			}
 
 			subtable := newTable(t.dialect, fieldType, seen, canAddr)
-			for _, subfield := range subtable.Fields {
+			for _, subfield := range subtable.allFields {
 				embedded = append(embedded, embeddedField{
 					prefix:     prefix,
 					index:      sf.Index,

--- a/schema/table_test.go
+++ b/schema/table_test.go
@@ -134,6 +134,28 @@ func TestTable(t *testing.T) {
 		require.Equal(t, []int{0, 1}, bar.Index)
 	})
 
+	t.Run("embed scanonly prefix", func(t *testing.T) {
+		type Model1 struct {
+			Foo string `bun:",scanonly"`
+			Bar string `bun:",scanonly"`
+		}
+
+		type Model2 struct {
+			Baz Model1 `bun:"embed:baz_"`
+		}
+
+		table := tables.Get(reflect.TypeOf((*Model2)(nil)))
+		require.Len(t, table.FieldMap, 2)
+
+		foo, ok := table.FieldMap["baz_foo"]
+		require.True(t, ok)
+		require.Equal(t, []int{0, 0}, foo.Index)
+
+		bar, ok := table.FieldMap["baz_bar"]
+		require.True(t, ok)
+		require.Equal(t, []int{0, 1}, bar.Index)
+	})
+
 	t.Run("scanonly", func(t *testing.T) {
 		type Model1 struct {
 			Foo string


### PR DESCRIPTION
This PR fixes the situation in which an `embed` tag is combined with a set of `scanonly` fields. 

This issue seems to be caused by https://github.com/uptrace/bun/commit/9052fc4cdf3a1e06facae872d0f2c12d0b1e5bfb - see the review comments below.

cc @vmihailenco 