### PR TITLE
feat: apply ModelTableExpr for SELECT query

### DIFF
--- a/internal/dbtest/query_test.go
+++ b/internal/dbtest/query_test.go
@@ -1045,6 +1045,12 @@ func TestQuery(t *testing.T) {
 			}
 			return db.NewInsert().Model(new(Model))
 		},
+		func(db *bun.DB) schema.QueryAppender {
+			return db.NewSelect().Model(new(Model)).ModelTableExpr("renamed")
+		},
+		func(db *bun.DB) schema.QueryAppender {
+			return db.NewSelect().Model(new(Model)).ModelTableExpr("renamed AS r")
+		},
 	}
 
 	timeRE := regexp.MustCompile(`'2\d{3}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(\.\d+)?(\+\d{2}:\d{2})?'`)

--- a/internal/dbtest/query_test.go
+++ b/internal/dbtest/query_test.go
@@ -1545,11 +1545,17 @@ func TestQuery(t *testing.T) {
 				return db.NewInsert().Model(new(Model))
 			},
 		},
-		func(db *bun.DB) schema.QueryAppender {
-			return db.NewSelect().Model(new(Model)).ModelTableExpr("renamed")
+		{
+			id: 167,
+			query: func(db *bun.DB) schema.QueryAppender {
+				return db.NewSelect().Model(new(Model)).ModelTableExpr("renamed")
+			},
 		},
-		func(db *bun.DB) schema.QueryAppender {
-			return db.NewSelect().Model(new(Model)).ModelTableExpr("renamed AS r")
+		{
+			id: 168,
+			query: func(db *bun.DB) schema.QueryAppender {
+				return db.NewSelect().Model(new(Model)).ModelTableExpr("renamed AS r")
+			},
 		},
 	}
 

--- a/internal/dbtest/testdata/snapshots/TestQuery-mariadb-167
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mariadb-167
@@ -1,0 +1,1 @@
+SELECT renamed.`id`, renamed.`str` FROM renamed

--- a/internal/dbtest/testdata/snapshots/TestQuery-mariadb-168
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mariadb-168
@@ -1,0 +1,1 @@
+SELECT r.`id`, r.`str` FROM renamed AS r

--- a/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-167
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-167
@@ -1,0 +1,1 @@
+SELECT renamed."id", renamed."str" FROM renamed

--- a/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-168
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-168
@@ -1,0 +1,1 @@
+SELECT r."id", r."str" FROM renamed AS r

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql5-167
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql5-167
@@ -1,0 +1,1 @@
+SELECT renamed.`id`, renamed.`str` FROM renamed

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql5-168
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql5-168
@@ -1,0 +1,1 @@
+SELECT r.`id`, r.`str` FROM renamed AS r

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql8-167
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql8-167
@@ -1,0 +1,1 @@
+SELECT renamed.`id`, renamed.`str` FROM renamed

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql8-168
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql8-168
@@ -1,0 +1,1 @@
+SELECT r.`id`, r.`str` FROM renamed AS r

--- a/internal/dbtest/testdata/snapshots/TestQuery-pg-167
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pg-167
@@ -1,0 +1,1 @@
+SELECT renamed."id", renamed."str" FROM renamed

--- a/internal/dbtest/testdata/snapshots/TestQuery-pg-168
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pg-168
@@ -1,0 +1,1 @@
+SELECT r."id", r."str" FROM renamed AS r

--- a/internal/dbtest/testdata/snapshots/TestQuery-pgx-167
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pgx-167
@@ -1,0 +1,1 @@
+SELECT renamed."id", renamed."str" FROM renamed

--- a/internal/dbtest/testdata/snapshots/TestQuery-pgx-168
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pgx-168
@@ -1,0 +1,1 @@
+SELECT r."id", r."str" FROM renamed AS r

--- a/internal/dbtest/testdata/snapshots/TestQuery-sqlite-167
+++ b/internal/dbtest/testdata/snapshots/TestQuery-sqlite-167
@@ -1,0 +1,1 @@
+SELECT renamed."id", renamed."str" FROM renamed

--- a/internal/dbtest/testdata/snapshots/TestQuery-sqlite-168
+++ b/internal/dbtest/testdata/snapshots/TestQuery-sqlite-168
@@ -1,0 +1,1 @@
+SELECT r."id", r."str" FROM renamed AS r

--- a/internal/tableparser/parser.go
+++ b/internal/tableparser/parser.go
@@ -1,0 +1,67 @@
+package tableparser
+
+import "strings"
+
+type Table struct {
+	name  string
+	alias string
+}
+
+func (t Table) IsZero() bool {
+	return t.name == "" && t.alias == ""
+}
+
+func (t Table) Name() string {
+	if t.alias != "" {
+		return t.alias
+	}
+	return t.name
+}
+
+func Parse(query string) Table {
+	if query == "" {
+		return Table{}
+	}
+	cleanedQuery := cleanQuery(query)
+	table := parseQuery(cleanedQuery)
+	return table
+}
+
+func cleanQuery(query string) string {
+	// Trim the query to remove any leading or trailing spaces.
+	trimmedQuery := strings.TrimSpace(query)
+
+	// Lowercase the keyword AS
+	cleanedQuery := strings.ReplaceAll(trimmedQuery, " AS ", " as ")
+
+	return cleanedQuery
+}
+
+func parseQuery(query string) Table {
+	if hasAlias(query) {
+		return parseWithAlias(query)
+	}
+	return Table{
+		name: query,
+	}
+}
+
+func hasAlias(query string) bool {
+	return strings.Contains(query, " as ") ||
+		strings.Contains(query, " ")
+}
+
+func parseWithAlias(query string) Table {
+	if strings.Contains(query, " as ") {
+		sp := strings.Split(query, " as ")
+		return Table{
+			name:  strings.TrimSpace(sp[0]),
+			alias: strings.TrimSpace(sp[1]),
+		}
+	}
+	sp := strings.Split(query, " ")
+	return Table{
+		name:  strings.TrimSpace(sp[0]),
+		alias: strings.TrimSpace(sp[1]),
+	}
+}

--- a/internal/tableparser/parser_test.go
+++ b/internal/tableparser/parser_test.go
@@ -1,0 +1,209 @@
+package tableparser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTable_IsZero(t *testing.T) {
+	type fields struct {
+		name  string
+		alias string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "return true if both name and alias are empty",
+			fields: fields{
+				name:  "",
+				alias: "",
+			},
+			want: true,
+		},
+		{
+			name: "return false if name is not empty",
+			fields: fields{
+				name:  "users",
+				alias: "",
+			},
+			want: false,
+		},
+		{
+			name: "return false if alias is not empty",
+			fields: fields{
+				name:  "",
+				alias: "u",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			table := Table{
+				name:  tt.fields.name,
+				alias: tt.fields.alias,
+			}
+			got := table.IsZero()
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestTable_Name(t *testing.T) {
+	type fields struct {
+		name  string
+		alias string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "return alias if alias is not empty",
+			fields: fields{
+				name:  "users",
+				alias: "u",
+			},
+			want: "u",
+		},
+		{
+			name: "return name if alias is empty",
+			fields: fields{
+				name:  "users",
+				alias: "",
+			},
+			want: "users",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			table := Table{
+				name:  tt.fields.name,
+				alias: tt.fields.alias,
+			}
+			got := table.Name()
+			require.Equal(t, tt.want, got)
+		})
+	}
+
+}
+
+func Test_cleanQuery(t *testing.T) {
+	type args struct {
+		query string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "check if the query without alias is trimmed",
+			args: args{
+				query: " users ",
+			},
+			want: "users",
+		},
+		{
+			name: "check if the query with alias is trimmed",
+			args: args{
+				query: " users as u ",
+			},
+			want: "users as u",
+		},
+		{
+			name: "check if the keyword AS is lowercase",
+			args: args{
+				query: "users AS u",
+			},
+			want: "users as u",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cleanQuery(tt.args.query)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_hasAlias(t *testing.T) {
+	type args struct {
+		query string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "check if the query has alias with keyword",
+			args: args{
+				query: "users as u",
+			},
+			want: true,
+		},
+		{
+			name: "check if the query has alias without keyword",
+			args: args{
+				query: "users u",
+			},
+			want: true,
+		},
+		{
+			name: "check if the query has no alias",
+			args: args{
+				query: "users",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasAlias(tt.args.query)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_parseWithAlias(t *testing.T) {
+	type args struct {
+		query string
+	}
+	tests := []struct {
+		name string
+		args args
+		want Table
+	}{
+		{
+			name: "parse query with keyword",
+			args: args{
+				query: "users as u",
+			},
+			want: Table{
+				name:  "users",
+				alias: "u",
+			},
+		},
+		{
+			name: "parse query without keyword",
+			args: args{
+				query: "users u",
+			},
+			want: Table{
+				name:  "users",
+				alias: "u",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseWithAlias(tt.args.query)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/query_column_add.go
+++ b/query_column_add.go
@@ -64,7 +64,7 @@ func (q *AddColumnQuery) TableExpr(query string, args ...interface{}) *AddColumn
 }
 
 func (q *AddColumnQuery) ModelTableExpr(query string, args ...interface{}) *AddColumnQuery {
-	q.modelTableName = schema.SafeQuery(query, args)
+	q.modelTable = schema.NewModelTable(query, args...)
 	return q
 }
 

--- a/query_column_drop.go
+++ b/query_column_drop.go
@@ -62,7 +62,7 @@ func (q *DropColumnQuery) TableExpr(query string, args ...interface{}) *DropColu
 }
 
 func (q *DropColumnQuery) ModelTableExpr(query string, args ...interface{}) *DropColumnQuery {
-	q.modelTableName = schema.SafeQuery(query, args)
+	q.modelTable = schema.NewModelTable(query, args...)
 	return q
 }
 

--- a/query_delete.go
+++ b/query_delete.go
@@ -75,7 +75,7 @@ func (q *DeleteQuery) TableExpr(query string, args ...interface{}) *DeleteQuery 
 }
 
 func (q *DeleteQuery) ModelTableExpr(query string, args ...interface{}) *DeleteQuery {
-	q.modelTableName = schema.SafeQuery(query, args)
+	q.modelTable = schema.NewModelTable(query, args...)
 	return q
 }
 

--- a/query_index_create.go
+++ b/query_index_create.go
@@ -93,7 +93,7 @@ func (q *CreateIndexQuery) TableExpr(query string, args ...interface{}) *CreateI
 }
 
 func (q *CreateIndexQuery) ModelTableExpr(query string, args ...interface{}) *CreateIndexQuery {
-	q.modelTableName = schema.SafeQuery(query, args)
+	q.modelTable = schema.NewModelTable(query, args...)
 	return q
 }
 

--- a/query_insert.go
+++ b/query_insert.go
@@ -86,7 +86,7 @@ func (q *InsertQuery) TableExpr(query string, args ...interface{}) *InsertQuery 
 }
 
 func (q *InsertQuery) ModelTableExpr(query string, args ...interface{}) *InsertQuery {
-	q.modelTableName = schema.SafeQuery(query, args)
+	q.modelTable = schema.NewModelTable(query, args...)
 	return q
 }
 

--- a/query_merge.go
+++ b/query_merge.go
@@ -83,7 +83,7 @@ func (q *MergeQuery) TableExpr(query string, args ...interface{}) *MergeQuery {
 }
 
 func (q *MergeQuery) ModelTableExpr(query string, args ...interface{}) *MergeQuery {
-	q.modelTableName = schema.SafeQuery(query, args)
+	q.modelTable = schema.NewModelTable(query, args...)
 	return q
 }
 

--- a/query_table_create.go
+++ b/query_table_create.go
@@ -76,7 +76,7 @@ func (q *CreateTableQuery) TableExpr(query string, args ...interface{}) *CreateT
 }
 
 func (q *CreateTableQuery) ModelTableExpr(query string, args ...interface{}) *CreateTableQuery {
-	q.modelTableName = schema.SafeQuery(query, args)
+	q.modelTable = schema.NewModelTable(query, args...)
 	return q
 }
 

--- a/query_table_drop.go
+++ b/query_table_drop.go
@@ -57,7 +57,7 @@ func (q *DropTableQuery) TableExpr(query string, args ...interface{}) *DropTable
 }
 
 func (q *DropTableQuery) ModelTableExpr(query string, args ...interface{}) *DropTableQuery {
-	q.modelTableName = schema.SafeQuery(query, args)
+	q.modelTable = schema.NewModelTable(query, args...)
 	return q
 }
 

--- a/query_table_truncate.go
+++ b/query_table_truncate.go
@@ -58,7 +58,7 @@ func (q *TruncateTableQuery) TableExpr(query string, args ...interface{}) *Trunc
 }
 
 func (q *TruncateTableQuery) ModelTableExpr(query string, args ...interface{}) *TruncateTableQuery {
-	q.modelTableName = schema.SafeQuery(query, args)
+	q.modelTable = schema.NewModelTable(query, args...)
 	return q
 }
 

--- a/query_update.go
+++ b/query_update.go
@@ -86,7 +86,7 @@ func (q *UpdateQuery) TableExpr(query string, args ...interface{}) *UpdateQuery 
 }
 
 func (q *UpdateQuery) ModelTableExpr(query string, args ...interface{}) *UpdateQuery {
-	q.modelTableName = schema.SafeQuery(query, args)
+	q.modelTable = schema.NewModelTable(query, args...)
 	return q
 }
 

--- a/schema/model_table.go
+++ b/schema/model_table.go
@@ -1,0 +1,27 @@
+package schema
+
+import "github.com/uptrace/bun/internal/tableparser"
+
+type ModelTable QueryWithArgs
+
+func NewModelTable(query string, args ...interface{}) ModelTable {
+	return ModelTable(SafeQuery(query, args))
+}
+
+func (t ModelTable) IsZero() bool {
+	return QueryWithArgs(t).IsZero()
+}
+
+func (t ModelTable) HasTableName() bool {
+	return !t.IsZero() && t.Query != ""
+}
+
+func (t ModelTable) AppendQuery(fmter Formatter, dst []byte) ([]byte, error) {
+	return QueryWithArgs(t).AppendQuery(fmter, dst)
+}
+
+func (t ModelTable) GetTableName(fmter Formatter) string {
+	formattedQuery := fmter.FormatQuery(t.Query, t.Args...)
+	table := tableparser.Parse(formattedQuery)
+	return table.Name()
+}

--- a/schema/table.go
+++ b/schema/table.go
@@ -45,11 +45,11 @@ type Table struct {
 	TypeName  string
 	ModelName string
 
-	Name              string
-	SQLName           Safe
-	SQLNameForSelects Safe
-	Alias             string
-	SQLAlias          Safe
+	Name              string // table name e.g. users
+	SQLName           Safe   // quoted table name e.g. `users`
+	SQLNameForSelects Safe   // quoted table name for SELECT command e.g. `users`
+	Alias             string // table alias e.g. u
+	SQLAlias          Safe   // quoted table alias e.g. `u`
 
 	allFields  []*Field // all fields including scanonly
 	Fields     []*Field // PKs + DataFields


### PR DESCRIPTION
## Overview 
This PR fixes #968. 

The ModelTableExpr method in the existing implementation simply overwrites the table name in the FROM clause, but not the table name used as the column name prefix in the SELECT clause (such as SELECT users.name). Therefore, the Insert, Update, and Delete processes were fine, but the Select process was not working as expected.

## What's changed 
### 1. add Table Parser
Extract table names and aliases from queries passed as arguments to ModelTableExpr method.

### 2. Update columns builder of select query
Consider the table name specified in ModelTableExpr when constructing columns in the SELECT clause.