### PR TITLE
fix: restore explicit column: name override

### DIFF
--- a/internal/dbtest/query_test.go
+++ b/internal/dbtest/query_test.go
@@ -1545,6 +1545,17 @@ func TestQuery(t *testing.T) {
 				return db.NewInsert().Model(new(Model))
 			},
 		},
+		{
+			id: 167,
+			query: func(db *bun.DB) schema.QueryAppender {
+				// specified option names
+				type Model struct {
+					bun.BaseModel `bun:"table:table"`
+					IsDefault     bool `bun:"column:default"`
+				}
+				return db.NewInsert().Model(new(Model))
+			},
+		},
 	}
 
 	timeRE := regexp.MustCompile(`'2\d{3}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(\.\d+)?(\+\d{2}:\d{2})?'`)

--- a/internal/dbtest/testdata/snapshots/TestQuery-mariadb-167
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mariadb-167
@@ -1,0 +1,1 @@
+INSERT INTO `table` (`default`) VALUES (FALSE)

--- a/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-167
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-167
@@ -1,0 +1,1 @@
+INSERT INTO "table" ("default") VALUES (0)

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql5-167
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql5-167
@@ -1,0 +1,1 @@
+INSERT INTO `table` (`default`) VALUES (FALSE)

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql8-167
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql8-167
@@ -1,0 +1,1 @@
+INSERT INTO `table` (`default`) VALUES (FALSE)

--- a/internal/dbtest/testdata/snapshots/TestQuery-pg-167
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pg-167
@@ -1,0 +1,1 @@
+INSERT INTO "table" ("default") VALUES (FALSE)

--- a/internal/dbtest/testdata/snapshots/TestQuery-pgx-167
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pgx-167
@@ -1,0 +1,1 @@
+INSERT INTO "table" ("default") VALUES (FALSE)

--- a/internal/dbtest/testdata/snapshots/TestQuery-sqlite-167
+++ b/internal/dbtest/testdata/snapshots/TestQuery-sqlite-167
@@ -1,0 +1,1 @@
+INSERT INTO "table" ("default") VALUES (FALSE)

--- a/schema/table.go
+++ b/schema/table.go
@@ -423,6 +423,10 @@ func (t *Table) newField(sf reflect.StructField, tag tagparser.Tag) *Field {
 		sqlName = tag.Name
 	}
 
+	if s, ok := tag.Option("column"); ok {
+		sqlName = s
+	}
+
 	for name := range tag.Options {
 		if !isKnownFieldOption(name) {
 			internal.Warn.Printf("%s.%s has unknown tag option: %q", t.TypeName, sf.Name, name)


### PR DESCRIPTION
Broken since v1.2.0~9 but previously untested.