### PR TITLE
Fix M2M relations for models with composite keys

### DIFF
--- a/internal/dbtest/orm_test.go
+++ b/internal/dbtest/orm_test.go
@@ -32,6 +32,7 @@ func TestORM(t *testing.T) {
 		{testM2MRelationExcludeColumn},
 		{testRelationBelongsToSelf},
 		{testCompositeHasMany},
+		{testCompositeM2M},
 	}
 
 	testEachDB(t, func(t *testing.T, dbName string, db *bun.DB) {
@@ -439,6 +440,78 @@ func testCompositeHasMany(t *testing.T, db *bun.DB) {
 	require.NoError(t, err)
 	require.Equal(t, "hr", department.No)
 	require.Equal(t, 2, len(department.Employees))
+}
+
+func testCompositeM2M(t *testing.T, db *bun.DB) {
+	type Item struct {
+		ID     int64 `bun:",pk"`
+		ShopID int64 `bun:",pk"`
+	}
+
+	type Order struct {
+		ID     int64  `bun:",pk"`
+		ShopID int64  `bun:",pk"`
+		Items  []Item `bun:"m2m:orders_to_items,join:Order=Item"`
+	}
+
+	type OrderToItem struct {
+		bun.BaseModel `bun:"table:orders_to_items"`
+
+		ShopID int64 `bun:""`
+
+		OrderID int64  `bun:""`
+		Order   *Order `bun:"rel:belongs-to,join:shop_id=shop_id,join:order_id=id"`
+		ItemID  int64  `bun:""`
+		Item    *Item  `bun:"rel:belongs-to,join:shop_id=shop_id,join:item_id=id"`
+	}
+
+	db.RegisterModel((*OrderToItem)(nil))
+	mustResetModel(t, ctx, db, (*Order)(nil), (*Item)(nil), (*OrderToItem)(nil))
+
+	items := []Item{
+		{ID: 1, ShopID: 22},
+		{ID: 2, ShopID: 22},
+		{ID: 3, ShopID: 22},
+	}
+	_, err := db.NewInsert().Model(&items).Exec(ctx)
+	require.NoError(t, err)
+
+	orders := []Order{
+		{ID: 12, ShopID: 22},
+		{ID: 13, ShopID: 22},
+	}
+	_, err = db.NewInsert().Model(&orders).Exec(ctx)
+	require.NoError(t, err)
+
+	orderItems := []OrderToItem{
+		{OrderID: 12, ItemID: 1, ShopID: 22},
+		{OrderID: 12, ItemID: 2, ShopID: 22},
+		{OrderID: 13, ItemID: 3, ShopID: 22},
+	}
+	_, err = db.NewInsert().Model(&orderItems).Exec(ctx)
+	require.NoError(t, err)
+
+	var ordersOut []Order
+
+	err = db.NewSelect().
+		Model(&ordersOut).
+		Where("id = ?", 12).
+		Relation("Items").
+		Scan(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(ordersOut))
+	require.Equal(t, 2, len(ordersOut[0].Items))
+
+	var ordersOut2 []Order
+
+	err = db.NewSelect().
+		Model(&ordersOut2).
+		Where("id = ?", 13).
+		Relation("Items").
+		Scan(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(ordersOut2))
+	require.Equal(t, 1, len(ordersOut2[0].Items))
 }
 
 type Genre struct {

--- a/internal/dbtest/orm_test.go
+++ b/internal/dbtest/orm_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/dbfixture"
+	"github.com/uptrace/bun/dialect"
 	"github.com/uptrace/bun/dialect/feature"
 )
 
@@ -443,6 +444,10 @@ func testCompositeHasMany(t *testing.T, db *bun.DB) {
 }
 
 func testCompositeM2M(t *testing.T, db *bun.DB) {
+	if db.Dialect().Name() == dialect.MSSQL {
+		t.Skip()
+	}
+
 	type Item struct {
 		ID     int64 `bun:",pk"`
 		ShopID int64 `bun:",pk"`

--- a/model_table_m2m.go
+++ b/model_table_m2m.go
@@ -91,9 +91,7 @@ func (m *m2mModel) Scan(src interface{}) error {
 	if field, ok := m.table.FieldMap[column]; ok {
 		return field.ScanValue(m.strct, src)
 	}
-
-	_, err := m.scanColumn(column, src)
-	return err
+	return m.scanM2MColumn(column, src)
 }
 
 func (m *m2mModel) scanM2MColumn(column string, src interface{}) error {

--- a/model_table_m2m.go
+++ b/model_table_m2m.go
@@ -24,7 +24,7 @@ var _ TableModel = (*m2mModel)(nil)
 func newM2MModel(j *relationJoin) *m2mModel {
 	baseTable := j.BaseModel.Table()
 	joinModel := j.JoinModel.(*sliceTableModel)
-	baseValues := baseValues(joinModel, j.basePKs())
+	baseValues := baseValues(joinModel, j.Relation.BaseFields)
 	if len(baseValues) == 0 {
 		return nil
 	}

--- a/model_table_m2m.go
+++ b/model_table_m2m.go
@@ -24,7 +24,7 @@ var _ TableModel = (*m2mModel)(nil)
 func newM2MModel(j *relationJoin) *m2mModel {
 	baseTable := j.BaseModel.Table()
 	joinModel := j.JoinModel.(*sliceTableModel)
-	baseValues := baseValues(joinModel, baseTable.PKs)
+	baseValues := baseValues(joinModel, j.basePKs())
 	if len(baseValues) == 0 {
 		return nil
 	}

--- a/model_table_m2m.go
+++ b/model_table_m2m.go
@@ -84,14 +84,16 @@ func (m *m2mModel) Scan(src interface{}) error {
 	m.scanIndex++
 
 	// Base pks must come first.
-	if m.scanIndex < len(m.rel.M2MBaseFields) {
+	if m.scanIndex <= len(m.rel.M2MBaseFields) {
 		return m.scanM2MColumn(column, src)
 	}
 
 	if field, ok := m.table.FieldMap[column]; ok {
 		return field.ScanValue(m.strct, src)
 	}
-	return m.scanM2MColumn(column, src)
+
+	_, err := m.scanColumn(column, src)
+	return err
 }
 
 func (m *m2mModel) scanM2MColumn(column string, src interface{}) error {

--- a/model_table_m2m.go
+++ b/model_table_m2m.go
@@ -92,13 +92,6 @@ func (m *m2mModel) Scan(src interface{}) error {
 		return err
 	}
 
-	for _, fk := range m.rel.M2MBaseFields {
-		if fk.Name == field.Name {
-			m.structKey = append(m.structKey, field.Value(m.strct).Interface())
-			break
-		}
-	}
-
 	return nil
 }
 

--- a/model_table_m2m.go
+++ b/model_table_m2m.go
@@ -80,8 +80,13 @@ func (m *m2mModel) ScanRows(ctx context.Context, rows *sql.Rows) (int, error) {
 }
 
 func (m *m2mModel) Scan(src interface{}) error {
+	defer func() { m.scanIndex++ }()
+
 	column := m.columns[m.scanIndex]
-	m.scanIndex++
+
+	if m.scanIndex < len(m.rel.M2MBaseFields) {
+		return m.scanM2MColumn(column, src)
+	}
 
 	field, ok := m.table.FieldMap[column]
 	if !ok {

--- a/relation_join.go
+++ b/relation_join.go
@@ -178,7 +178,7 @@ func (j *relationJoin) m2mQuery(q *SelectQuery) *SelectQuery {
 	baseTable := j.BaseModel.Table()
 
 	if j.Relation.M2MTable != nil {
-		fields := append(j.Relation.M2MBaseFields, j.Relation.M2MJoinFields...)
+		fields := j.Relation.M2MBaseFields
 
 		b := make([]byte, 0, len(fields))
 		b = appendColumns(b, j.Relation.M2MTable.SQLAlias, fields)

--- a/relation_join.go
+++ b/relation_join.go
@@ -177,6 +177,7 @@ func (j *relationJoin) m2mQuery(q *SelectQuery) *SelectQuery {
 	index := j.JoinModel.parentIndex()
 
 	if j.Relation.M2MTable != nil {
+		// We only need base pks to park joined models to the base model.
 		fields := j.Relation.M2MBaseFields
 
 		b := make([]byte, 0, len(fields))
@@ -201,8 +202,7 @@ func (j *relationJoin) m2mQuery(q *SelectQuery) *SelectQuery {
 		join = append(join, col.SQLName...)
 	}
 	join = append(join, ") IN ("...)
-
-	join = appendChildValues(fmter, join, j.BaseModel.rootValue(), index, j.basePKs())
+	join = appendChildValues(fmter, join, j.BaseModel.rootValue(), index, j.Relation.BaseFields)
 	join = append(join, ")"...)
 	q = q.Join(internal.String(join))
 
@@ -218,15 +218,6 @@ func (j *relationJoin) m2mQuery(q *SelectQuery) *SelectQuery {
 	q = q.Apply(j.hasManyColumns)
 
 	return q
-}
-
-func (j *relationJoin) basePKs() []*schema.Field {
-	baseTable := j.BaseModel.Table()
-	pks := make([]*schema.Field, 0, len(baseTable.PKs))
-	for _, f := range j.Relation.BaseFields {
-		pks = append(pks, baseTable.FieldMap[f.Name])
-	}
-	return pks
 }
 
 func (j *relationJoin) hasParent() bool {


### PR DESCRIPTION
This PR adds support for M2M relations with composite keys. This feature was probably supposed to be working previously, but was not tested and [turned out](https://github.com/uptrace/bun/issues/992) to be buggy. Existing functionality is not affected, according to the tests.

Commits:
- **fix(m2m join): don't query join columns**
- **fix(m2m): enforce ordering of PKs of base table**
- **fix(m2m): remove unneeded appending to struct key**
- **fix(m2m): correctly infer which columns belong to which model**
- **feat: add test for M2M relations with composite keys**

Closes https://github.com/uptrace/bun/issues/992.
