### PR TITLE
feat: add mechanism for prefixing queries with a comment string

### DIFF
--- a/query_base_test.go
+++ b/query_base_test.go
@@ -1,0 +1,40 @@
+package bun
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryComment(t *testing.T) {
+	ctx := context.Background()
+	ctxWithComment := ContextWithComment(ctx, "test comment from context")
+
+	q := &SelectQuery{}
+
+	b := q.appendComment(ctx, nil)
+	require.Equal(t, "", string(b))
+
+	b = q.appendComment(ctxWithComment, nil)
+	require.Equal(t, "/*test comment from context*/ ", string(b))
+
+	qWithComment := q.Comment("test comment from api")
+	b = qWithComment.appendComment(ctx, nil)
+	require.Equal(t, "/*test comment from api*/ ", string(b))
+
+	b = qWithComment.appendComment(ctxWithComment, nil)
+	require.Equal(t, "/*test comment from api*/ ", string(b))
+
+	b = qWithComment.Comment("test with /").appendComment(ctx, nil)
+	require.Equal(t, "/*test with /*/ ", string(b))
+
+	b = qWithComment.Comment("test with *").appendComment(ctx, nil)
+	require.Equal(t, "/*test with **/ ", string(b))
+
+	b = qWithComment.Comment("test with */ closing").appendComment(ctx, nil)
+	require.Equal(t, "/*test with \\*\\/ closing*/ ", string(b))
+
+	b = qWithComment.Comment("test with closing at end */").appendComment(ctx, nil)
+	require.Equal(t, "/*test with closing at end \\*\\/*/ ", string(b))
+}

--- a/query_delete.go
+++ b/query_delete.go
@@ -44,6 +44,13 @@ func (q *DeleteQuery) Err(err error) *DeleteQuery {
 	return q
 }
 
+// Comment prepends a comment to the beginning of the query.
+// This is useful for debugging or identifying queries in database logs.
+func (q *DeleteQuery) Comment(c string) *DeleteQuery {
+	q.setComment(c)
+	return q
+}
+
 // Apply calls the fn passing the DeleteQuery as an argument.
 func (q *DeleteQuery) Apply(fn func(*DeleteQuery) *DeleteQuery) *DeleteQuery {
 	if fn != nil {
@@ -260,7 +267,7 @@ func (q *DeleteQuery) scanOrExec(
 	}
 
 	// Generate the query before checking hasReturning.
-	queryBytes, err := q.AppendQuery(q.db.fmter, q.db.makeQueryBytes())
+	queryBytes, err := q.AppendQuery(q.db.fmter, q.appendComment(ctx, q.db.makeQueryBytes()))
 	if err != nil {
 		return nil, err
 	}
@@ -340,6 +347,13 @@ func (q *DeleteQuery) ApplyQueryBuilder(fn func(QueryBuilder) QueryBuilder) *Del
 
 type deleteQueryBuilder struct {
 	*DeleteQuery
+}
+
+// Comment prepends a comment to the beginning of the query.
+// This is useful for debugging or identifying queries in database logs.
+func (q *deleteQueryBuilder) Comment(c string) QueryBuilder {
+	q.setComment(c)
+	return q
 }
 
 func (q *deleteQueryBuilder) WhereGroup(

--- a/query_insert.go
+++ b/query_insert.go
@@ -53,6 +53,13 @@ func (q *InsertQuery) Err(err error) *InsertQuery {
 	return q
 }
 
+// Comment prepends a comment to the beginning of the query.
+// This is useful for debugging or identifying queries in database logs.
+func (q *InsertQuery) Comment(c string) *InsertQuery {
+	q.setComment(c)
+	return q
+}
+
 // Apply calls the fn passing the SelectQuery as an argument.
 func (q *InsertQuery) Apply(fn func(*InsertQuery) *InsertQuery) *InsertQuery {
 	if fn != nil {
@@ -575,7 +582,7 @@ func (q *InsertQuery) scanOrExec(
 	}
 
 	// Generate the query before checking hasReturning.
-	queryBytes, err := q.AppendQuery(q.db.fmter, q.db.makeQueryBytes())
+	queryBytes, err := q.AppendQuery(q.db.fmter, q.appendComment(ctx, q.db.makeQueryBytes()))
 	if err != nil {
 		return nil, err
 	}

--- a/query_merge.go
+++ b/query_merge.go
@@ -50,6 +50,13 @@ func (q *MergeQuery) Err(err error) *MergeQuery {
 	return q
 }
 
+// Comment prepends a comment to the beginning of the query.
+// This is useful for debugging or identifying queries in database logs.
+func (q *MergeQuery) Comment(c string) *MergeQuery {
+	q.setComment(c)
+	return q
+}
+
 // Apply calls the fn passing the MergeQuery as an argument.
 func (q *MergeQuery) Apply(fn func(*MergeQuery) *MergeQuery) *MergeQuery {
 	if fn != nil {
@@ -232,7 +239,7 @@ func (q *MergeQuery) scanOrExec(
 	}
 
 	// Generate the query before checking hasReturning.
-	queryBytes, err := q.AppendQuery(q.db.fmter, q.db.makeQueryBytes())
+	queryBytes, err := q.AppendQuery(q.db.fmter, q.appendComment(ctx, q.db.makeQueryBytes()))
 	if err != nil {
 		return nil, err
 	}

--- a/query_update.go
+++ b/query_update.go
@@ -53,6 +53,13 @@ func (q *UpdateQuery) Err(err error) *UpdateQuery {
 	return q
 }
 
+// Comment prepends a comment to the beginning of the query.
+// This is useful for debugging or identifying queries in database logs.
+func (q *UpdateQuery) Comment(c string) *UpdateQuery {
+	q.setComment(c)
+	return q
+}
+
 // Apply calls the fn passing the SelectQuery as an argument.
 func (q *UpdateQuery) Apply(fn func(*UpdateQuery) *UpdateQuery) *UpdateQuery {
 	if fn != nil {
@@ -506,7 +513,7 @@ func (q *UpdateQuery) scanOrExec(
 	}
 
 	// Generate the query before checking hasReturning.
-	queryBytes, err := q.AppendQuery(q.db.fmter, q.db.makeQueryBytes())
+	queryBytes, err := q.AppendQuery(q.db.fmter, q.appendComment(ctx, q.db.makeQueryBytes()))
 	if err != nil {
 		return nil, err
 	}
@@ -602,6 +609,13 @@ func (q *UpdateQuery) ApplyQueryBuilder(fn func(QueryBuilder) QueryBuilder) *Upd
 
 type updateQueryBuilder struct {
 	*UpdateQuery
+}
+
+// Comment prepends a comment to the beginning of the query.
+// This is useful for debugging or identifying queries in database logs.
+func (q *updateQueryBuilder) Comment(c string) QueryBuilder {
+	q.setComment(c)
+	return q
 }
 
 func (q *updateQueryBuilder) WhereGroup(


### PR DESCRIPTION
This change proposes a new `Comment(string)` method and `ContextWithComment(context.Context, string)` function for prepending a comment to a SQL query.

Here's simple example:

```go
// using the query API
err := db.NewSelect().
    Model(&products).
    Where("description like ?", d).
    Comment("customer:"+customerID).
    Scan(ctx)

// using a context
qctx := bun.ContextWithComment(ctx, "customer:"+customerID)
err := db.NewSelect().
    Model(&products).
    Where("description LIKE ?", d).
    Scan(qctx)
```
This would produce a query that looks like:

```sql
/*customer:01J1P97P3AP7V287B57P7055CZ*/ SELECT * FROM products WHERE description LIKE '%red%'
```

This may warrant a bit of discussion first, but I wanted to include the code with the proposal. I have had this code running in production since April with no problems. It appears that others may be interested in this as well: https://github.com/uptrace/bun/issues/998

My immediate use case for this is to add a comment to a query with tracing/debug information that will show up in the process list/`pg_stat_activity`, but there are certainly other uses for this functionality.