### PR TITLE
add context to zerolog event hook

### DIFF
--- a/extra/bunzerolog/zerohook.go
+++ b/extra/bunzerolog/zerohook.go
@@ -95,6 +95,7 @@ func NewQueryHook(opts ...Option) *QueryHook {
 			duration := h.now().Sub(event.StartTime)
 
 			return zerevent.
+				Ctx(ctx).
 				Err(event.Err).
 				Str("query", event.Query).
 				Str("operation", event.Operation()).


### PR DESCRIPTION
Add context to the zerolog event hook so that other hooks can benefit from it, such as printing the request ID