### PR TITLE
fix: allow Limit() without Order() with MSSQL

### DIFF
--- a/query_select.go
+++ b/query_select.go
@@ -541,7 +541,6 @@ func (q *SelectQuery) appendQuery(
 		// MSSQL: allows Limit() without Order() as per https://stackoverflow.com/a/36156953
 		if q.limit > 0 && len(q.order) == 0 && fmter.Dialect().Name() == dialect.MSSQL {
 			b = append(b, "0 AS _temp_sort, "...)
-			q.order = []schema.QueryWithArgs{schema.UnsafeIdent("_temp_sort")}
 		}
 
 		b, err = q.appendColumns(fmter, b)

--- a/query_select.go
+++ b/query_select.go
@@ -538,6 +538,11 @@ func (q *SelectQuery) appendQuery(
 	if count && !cteCount {
 		b = append(b, "count(*)"...)
 	} else {
+		// Allows Limit() without Order() with MSSQL as per https://stackoverflow.com/a/36156953
+		if q.limit > 0 && fmter.Dialect().Features().Has(feature.OffsetFetch) && len(q.order) == 0 {
+			b = append(b, "0 AS _temp_sort, "...)
+			q.order = []schema.QueryWithArgs{schema.UnsafeIdent("_temp_sort")}
+		}
 		b, err = q.appendColumns(fmter, b)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Implements workaround from https://stackoverflow.com/a/36156953 for all backends supporting `feature.OffsetFetch` from ISO/ANSI SQL:2008, which specifies `ORDER BY` as a requirement. This should be tested further if more backends are to be added (such as Oracle in #995 – this feature is not enable there, and there seems to be an impact noted by https://stackoverflow.com/q/48620590 and https://stackoverflow.com/q/59864964).

Closes #811