### PR TITLE
fix: gracefully handle empty hstore in pgdialect

### DIFF
--- a/dialect/pgdialect/append_test.go
+++ b/dialect/pgdialect/append_test.go
@@ -1,0 +1,39 @@
+package pgdialect
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun/schema"
+)
+
+func TestHStoreAppender(t *testing.T) {
+	tests := []struct {
+		input      map[string]string
+		expectedIn []string // maps being unsorted, multiple expected output are valid
+	}{
+		{nil, []string{`NULL`}},
+		{map[string]string{}, []string{`''`}},
+
+		{map[string]string{"": ""}, []string{`'""=>""'`}},
+		{map[string]string{`\`: `\`}, []string{`'"\\"=>"\\"'`}},
+		{map[string]string{"'": "'"}, []string{`'"''"=>"''"'`}},
+		{map[string]string{`'"{}`: `'"{}`}, []string{`'"''\"{}"=>"''\"{}"'`}},
+
+		{map[string]string{"1": "2", "3": "4"}, []string{`'"1"=>"2","3"=>"4"'`, `'"3"=>"4","1"=>"2"'`}},
+		{map[string]string{"1": ""}, []string{`'"1"=>""'`}},
+		{map[string]string{"1": "NULL"}, []string{`'"1"=>"NULL"'`}},
+		{map[string]string{"{1}": "{2}", "{3}": "{4}"}, []string{`'"{1}"=>"{2}","{3}"=>"{4}"'`, `'"{3}"=>"{4}","{1}"=>"{2}"'`}},
+	}
+
+	appendFunc := pgDialect.hstoreAppender(reflect.TypeOf(map[string]string{}))
+
+	for i, test := range tests {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			got := appendFunc(schema.NewFormatter(pgDialect), []byte{}, reflect.ValueOf(test.input))
+			require.Contains(t, test.expectedIn, string(got))
+		})
+	}
+}

--- a/dialect/pgdialect/hstore_parser.go
+++ b/dialect/pgdialect/hstore_parser.go
@@ -16,7 +16,7 @@ type hstoreParser struct {
 
 func newHStoreParser(b []byte) *hstoreParser {
 	p := new(hstoreParser)
-	if len(b) < 6 || b[0] != '"' {
+	if len(b) != 0 && (len(b) < 6 || b[0] != '"') {
 		p.err = fmt.Errorf("pgdialect: can't parse hstore: %q", b)
 		return p
 	}
@@ -83,7 +83,7 @@ func (p *hstoreParser) readNext() error {
 	default:
 		value := p.p.ReadLiteral(ch)
 		if bytes.Equal(value, []byte("NULL")) {
-			value = nil
+			p.value = ""
 		}
 		p.skipComma()
 		return nil

--- a/dialect/pgdialect/hstore_parser_test.go
+++ b/dialect/pgdialect/hstore_parser_test.go
@@ -12,6 +12,8 @@ func TestHStoreParser(t *testing.T) {
 		s string
 		m map[string]string
 	}{
+		{``, map[string]string{}},
+
 		{`""=>""`, map[string]string{"": ""}},
 		{`"\\"=>"\\"`, map[string]string{`\`: `\`}},
 		{`"'"=>"'"`, map[string]string{"'": "'"}},

--- a/internal/dbtest/pg_test.go
+++ b/internal/dbtest/pg_test.go
@@ -750,6 +750,22 @@ func TestPostgresHStoreQuote(t *testing.T) {
 	require.Equal(t, wanted, m)
 }
 
+func TestPostgresHStoreEmpty(t *testing.T) {
+	db := pg(t)
+	t.Cleanup(func() { db.Close() })
+
+	_, err := db.Exec(`CREATE EXTENSION IF NOT EXISTS HSTORE;`)
+	require.NoError(t, err)
+
+	wanted := map[string]string{}
+	m := make(map[string]string)
+	err = db.NewSelect().
+		ColumnExpr("?::hstore", pgdialect.HStore(wanted)).
+		Scan(ctx, pgdialect.HStore(&m))
+	require.NoError(t, err)
+	require.Equal(t, wanted, m)
+}
+
 func TestPostgresSkipupdateField(t *testing.T) {
 	type Model struct {
 		ID        int64 `bun:",pk,autoincrement"`


### PR DESCRIPTION
In the current implementation of `hstore` in `github.com/uptrace/bun/dialect/pgdialect`, an empty `hstore` is encoded properly in the database as `''` but can not be retrieved.

It is handled properly for a `var md map[string]string = nil` when `NULL` is inserted in database and an empty map is returned when querying back the record, but when using a `map[string]string{}` it will insert `''` (which is expected) but will fail with the following error:

```
sql: Scan error on column index 8, name "metadata": bun: can't parse hstore: ""
```

This PR make sure an empty `hstore` is handled gracefully in the `hstoreParser` as well as adds test cases for this issues in `pgdialect` itself (for the parser AND the appender) as well as in the `internal/dbtest` package.

This fix is relatively crucial to us, as we tend to store user defined metadata in `hstore` and it may happen that a user removes all key value pairs from there. Currently, we have to check if the changes made to a metadata field makes it empty and force the field to be null, being able to handle empty hstore gracefully at the database driver level would make our life quite easier here as it seems like a legitimate use of that type.