### PR TITLE
Fix: Remove duplicated mutex unlock

### DIFF
--- a/schema/tables.go
+++ b/schema/tables.go
@@ -45,7 +45,6 @@ func (t *Tables) Get(typ reflect.Type) *Table {
 	defer t.mu.Unlock()
 
 	if v, ok := t.tables.Load(typ); ok {
-		t.mu.Unlock()
 		return v
 	}
 


### PR DESCRIPTION
We receive panic `fatal error: sync: unlock of unlocked mutex` on fixtures loading.