### PR TITLE
pref: Optimize select query performance when there is no limit and offset

### DIFF
--- a/query_select.go
+++ b/query_select.go
@@ -856,52 +856,57 @@ func (q *SelectQuery) Exec(ctx context.Context, dest ...interface{}) (res sql.Re
 }
 
 func (q *SelectQuery) Scan(ctx context.Context, dest ...interface{}) error {
+	_, err := q.scanResult(ctx, dest...)
+	return err
+}
+
+func (q *SelectQuery) scanResult(ctx context.Context, dest ...interface{}) (sql.Result, error) {
 	if q.err != nil {
-		return q.err
+		return nil, q.err
 	}
 
 	model, err := q.getModel(dest)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if q.table != nil {
 		if err := q.beforeSelectHook(ctx); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	if err := q.beforeAppendModel(ctx, q); err != nil {
-		return err
+		return nil, err
 	}
 
 	queryBytes, err := q.AppendQuery(q.db.fmter, q.db.makeQueryBytes())
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	query := internal.String(queryBytes)
 
 	res, err := q.scan(ctx, q, query, model, true)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if n, _ := res.RowsAffected(); n > 0 {
 		if tableModel, ok := model.(TableModel); ok {
 			if err := q.selectJoins(ctx, tableModel.getJoins()); err != nil {
-				return err
+				return nil, err
 			}
 		}
 	}
 
 	if q.table != nil {
 		if err := q.afterSelectHook(ctx); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	return nil
+	return res, nil
 }
 
 func (q *SelectQuery) beforeSelectHook(ctx context.Context) error {
@@ -946,6 +951,16 @@ func (q *SelectQuery) Count(ctx context.Context) (int, error) {
 }
 
 func (q *SelectQuery) ScanAndCount(ctx context.Context, dest ...interface{}) (int, error) {
+	if q.offset == 0 && q.limit == 0 {
+		// If there is no limit and offset, we can use a single query to get the count and scan
+		if res, err := q.scanResult(ctx, dest...); err != nil {
+			return 0, err
+		} else if n, err := res.RowsAffected(); err != nil {
+			return 0, err
+		} else {
+			return int(n), nil
+		}
+	}
 	if _, ok := q.conn.(*DB); ok {
 		return q.scanAndCountConc(ctx, dest...)
 	}


### PR DESCRIPTION
If there is no limit and offset, we can use a single query to get the count and scan, the additional count query is not necessary.

```go
// If there is no limit and offset 
bundb.NewSelect().Model(users).Where("age > ?", 59).ScanAndCount(ctx)
// SELECT user.id, user.name, user.age FROM users WHERE user.age > 59;

// Otherwise
bundb.NewSelect().Model(users).Where("age > ?", 59).Offset(0).Limit(10).ScanAndCount(ctx)
// SELECT user.id, user.name, user.age FROM users WHERE user.age > 59;
// SELECT COUNT(*) FROM users WHERE user.age > 59;
```

In this way, we can use the more general repos layer method definition, like this:

```go
type UsersRepo interface {
    // Implemention:
    //
    // var users []*models.User
    // query := r.bdb.NewSelect().Model(&users)
    // for _, mod := range mods {
    //     query = query.Apply(mod)
    // }
    // return query.ScanAndCount(ctx)
    //
    // Example 1:
    //
    //   users, _, err := usersRepo.FindUsersOlderThan(ctx, 59)
    //
    // Example 2:
    //
    //   users, total, err := usersRepo.FindUsersOlderThan(ctx, 59, func(sq *bun.SelectQuery) *bun.SelectQuery {
    //     return sq.Offset(0).Limit(10)
    //   })
    FindUsersOlderThan(ctx context.Context, age int, mods ...func(*bun.SelectQuery) *bun.SelectQuery) ([]*models.User, int, error)
}
```