### PR TITLE
Fix: return column option back

### DIFF
--- a/schema/table.go
+++ b/schema/table.go
@@ -401,6 +401,10 @@ func (t *Table) newField(sf reflect.StructField, tag tagparser.Tag) *Field {
 		sqlName = tag.Name
 	}
 
+	if s, ok := tag.Option("column"); ok {
+		sqlName = s
+	}
+
 	for name := range tag.Options {
 		if !isKnownFieldOption(name) {
 			internal.Warn.Printf("%s.%s has unknown tag option: %q", t.TypeName, sf.Name, name)


### PR DESCRIPTION
"column" option removed here: https://github.com/uptrace/bun/commit/9052fc4cdf3a1e06facae872d0f2c12d0b1e5bfb#diff-abecd8d935ca8952a3554e15fa6989972dd0cea6de3410b6541931883b0d6d84L314
It would be nice to return it.