### PR TITLE
feat: Enhance Apply method to accept multiple functions

### DIFF
--- a/query_column_add.go
+++ b/query_column_add.go
@@ -42,9 +42,12 @@ func (q *AddColumnQuery) Err(err error) *AddColumnQuery {
 	return q
 }
 
-func (q *AddColumnQuery) Apply(fn func(*AddColumnQuery) *AddColumnQuery) *AddColumnQuery {
-	if fn != nil {
-		return fn(q)
+// Apply calls each function in fns, passing the AddColumnQuery as an argument.
+func (q *AddColumnQuery) Apply(fns ...func(*AddColumnQuery) *AddColumnQuery) *AddColumnQuery {
+	for _, fn := range fns {
+		if fn != nil {
+			q = fn(q)
+		}
 	}
 	return q
 }

--- a/query_column_drop.go
+++ b/query_column_drop.go
@@ -40,9 +40,12 @@ func (q *DropColumnQuery) Err(err error) *DropColumnQuery {
 	return q
 }
 
-func (q *DropColumnQuery) Apply(fn func(*DropColumnQuery) *DropColumnQuery) *DropColumnQuery {
-	if fn != nil {
-		return fn(q)
+// Apply calls each function in fns, passing the DropColumnQuery as an argument.
+func (q *DropColumnQuery) Apply(fns ...func(*DropColumnQuery) *DropColumnQuery) *DropColumnQuery {
+	for _, fn := range fns {
+		if fn != nil {
+			q = fn(q)
+		}
 	}
 	return q
 }

--- a/query_delete.go
+++ b/query_delete.go
@@ -44,10 +44,12 @@ func (q *DeleteQuery) Err(err error) *DeleteQuery {
 	return q
 }
 
-// Apply calls the fn passing the DeleteQuery as an argument.
-func (q *DeleteQuery) Apply(fn func(*DeleteQuery) *DeleteQuery) *DeleteQuery {
-	if fn != nil {
-		return fn(q)
+// Apply calls each function in fns, passing the DeleteQuery as an argument.
+func (q *DeleteQuery) Apply(fns ...func(*DeleteQuery) *DeleteQuery) *DeleteQuery {
+	for _, fn := range fns {
+		if fn != nil {
+			q = fn(q)
+		}
 	}
 	return q
 }

--- a/query_insert.go
+++ b/query_insert.go
@@ -53,10 +53,12 @@ func (q *InsertQuery) Err(err error) *InsertQuery {
 	return q
 }
 
-// Apply calls the fn passing the SelectQuery as an argument.
-func (q *InsertQuery) Apply(fn func(*InsertQuery) *InsertQuery) *InsertQuery {
-	if fn != nil {
-		return fn(q)
+// Apply calls each function in fns, passing the InsertQuery as an argument.
+func (q *InsertQuery) Apply(fns ...func(*InsertQuery) *InsertQuery) *InsertQuery {
+	for _, fn := range fns {
+		if fn != nil {
+			q = fn(q)
+		}
 	}
 	return q
 }

--- a/query_merge.go
+++ b/query_merge.go
@@ -50,10 +50,12 @@ func (q *MergeQuery) Err(err error) *MergeQuery {
 	return q
 }
 
-// Apply calls the fn passing the MergeQuery as an argument.
-func (q *MergeQuery) Apply(fn func(*MergeQuery) *MergeQuery) *MergeQuery {
-	if fn != nil {
-		return fn(q)
+// Apply calls each function in fns, passing the MergeQuery as an argument.
+func (q *MergeQuery) Apply(fns ...func(*MergeQuery) *MergeQuery) *MergeQuery {
+	for _, fn := range fns {
+		if fn != nil {
+			q = fn(q)
+		}
 	}
 	return q
 }

--- a/query_select.go
+++ b/query_select.go
@@ -66,10 +66,12 @@ func (q *SelectQuery) Err(err error) *SelectQuery {
 	return q
 }
 
-// Apply calls the fn passing the SelectQuery as an argument.
-func (q *SelectQuery) Apply(fn func(*SelectQuery) *SelectQuery) *SelectQuery {
-	if fn != nil {
-		return fn(q)
+// Apply calls each function in fns, passing the SelectQuery as an argument.
+func (q *SelectQuery) Apply(fns ...func(*SelectQuery) *SelectQuery) *SelectQuery {
+	for _, fn := range fns {
+		if fn != nil {
+			q = fn(q)
+		}
 	}
 	return q
 }

--- a/query_update.go
+++ b/query_update.go
@@ -53,10 +53,12 @@ func (q *UpdateQuery) Err(err error) *UpdateQuery {
 	return q
 }
 
-// Apply calls the fn passing the SelectQuery as an argument.
-func (q *UpdateQuery) Apply(fn func(*UpdateQuery) *UpdateQuery) *UpdateQuery {
-	if fn != nil {
-		return fn(q)
+// Apply calls each function in fns, passing the UpdateQuery as an argument.
+func (q *UpdateQuery) Apply(fns ...func(*UpdateQuery) *UpdateQuery) *UpdateQuery {
+	for _, fn := range fns {
+		if fn != nil {
+			q = fn(q)
+		}
 	}
 	return q
 }


### PR DESCRIPTION
This pull request includes updates to the `Apply` method across multiple query types to support variadic function arguments, allowing multiple functions to be applied in sequence, these changes **will not break** existing calls.

```go
type UsersRepo interface {
    // Implemention:
    //
    // var users []*models.User
    // query := r.bdb.NewSelect().Model(&users).Apply(fns...)
    // return query.ScanAndCount(ctx)
    //
    // Example 1:
    //
    //   // find users 
    //   users, _, err := usersRepo.FindUsers(ctx,
    //       func(sq *bun.SelectQuery) *bun.SelectQuery {
    //           return sq.Where("age > ?", 59).Order("age DESC")
    //       },
    //       func(sq *bun.SelectQuery) *bun.SelectQuery {
    //           return sq.Offset(0).Limit(100)
    //       },
    //   )
    FindUsers(ctx context.Context, fns ...func(*bun.SelectQuery) *bun.SelectQuery) ([]*models.User, int, error)
}
```

BTW, some comments were fixed.