### PR TITLE
Fix #981: unique tag in embeded structure

### DIFF
--- a/schema/table.go
+++ b/schema/table.go
@@ -174,6 +174,10 @@ func (t *Table) processFields(typ reflect.Type, canAddr bool) {
 				}
 			}
 
+			if subtable.Unique != nil && t.Unique == nil {
+				t.Unique = subtable.Unique
+			}
+
 			continue
 		}
 


### PR DESCRIPTION
‌‌In the case where there were many changes in version 1.17 + 1 commit, subsequent versions did not work well with a large number of embeds in my scenario. For this reason, I made minor revisions to make it work. When a unique is detected in the subtable, it is set as the only unique. Generally, Unique tags are not used too much. In my scenario, it just solved the problem.