### PR TITLE
Follow-up #926

### DIFF
--- a/dialect/pgdialect/alter_table.go
+++ b/dialect/pgdialect/alter_table.go
@@ -10,7 +10,7 @@ import (
 	"github.com/uptrace/bun/schema"
 )
 
-func (d *Dialect) Migrator(db *bun.DB, schemaName string) sqlschema.Migrator {
+func (d *Dialect) NewMigrator(db *bun.DB, schemaName string) sqlschema.Migrator {
 	return &migrator{db: db, schemaName: schemaName, BaseMigrator: sqlschema.NewBaseMigrator(db)}
 }
 

--- a/dialect/pgdialect/alter_table.go
+++ b/dialect/pgdialect/alter_table.go
@@ -202,7 +202,7 @@ func (m *migrator) changeColumnType(fmter schema.Formatter, b []byte, colDef *mi
 	got, want := colDef.From, colDef.To
 
 	inspector := m.db.Dialect().(sqlschema.InspectorDialect)
-	if !inspector.EquivalentType(want, got) {
+	if !inspector.CompareType(want, got) {
 		appendAlterColumn()
 		b = append(b, " SET DATA TYPE "...)
 		if b, err = want.AppendQuery(fmter, b); err != nil {

--- a/dialect/pgdialect/inspector.go
+++ b/dialect/pgdialect/inspector.go
@@ -15,7 +15,7 @@ type (
 	Column = sqlschema.BaseColumn
 )
 
-func (d *Dialect) Inspector(db *bun.DB, options ...sqlschema.InspectorOption) sqlschema.Inspector {
+func (d *Dialect) NewInspector(db *bun.DB, options ...sqlschema.InspectorOption) sqlschema.Inspector {
 	return newInspector(db, options...)
 }
 

--- a/dialect/pgdialect/sqltype.go
+++ b/dialect/pgdialect/sqltype.go
@@ -125,7 +125,7 @@ var (
 	timestampTz = newAliases(sqltype.Timestamp, pgTypeTimestampTz, pgTypeTimestampWithTz)
 )
 
-func (d *Dialect) EquivalentType(col1, col2 sqlschema.Column) bool {
+func (d *Dialect) CompareType(col1, col2 sqlschema.Column) bool {
 	typ1, typ2 := strings.ToUpper(col1.GetSQLType()), strings.ToUpper(col2.GetSQLType())
 
 	if typ1 == typ2 {

--- a/dialect/pgdialect/sqltype_test.go
+++ b/dialect/pgdialect/sqltype_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/uptrace/bun/migrate/sqlschema"
 )
 
-func TestInspectorDialect_EquivalentType(t *testing.T) {
+func TestInspectorDialect_CompareType(t *testing.T) {
 	d := New()
 
 	t.Run("common types", func(t *testing.T) {
@@ -41,7 +41,7 @@ func TestInspectorDialect_EquivalentType(t *testing.T) {
 				eq = " !~ "
 			}
 			t.Run(tt.typ1+eq+tt.typ2, func(t *testing.T) {
-				got := d.EquivalentType(
+				got := d.CompareType(
 					&sqlschema.BaseColumn{SQLType: tt.typ1},
 					&sqlschema.BaseColumn{SQLType: tt.typ2},
 				)
@@ -77,7 +77,7 @@ func TestInspectorDialect_EquivalentType(t *testing.T) {
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				got := d.EquivalentType(&tt.col1, &tt.col2)
+				got := d.CompareType(&tt.col1, &tt.col2)
 				require.Equal(t, tt.want, got)
 			})
 		}

--- a/internal/dbtest/inspect_test.go
+++ b/internal/dbtest/inspect_test.go
@@ -335,7 +335,7 @@ func TestDatabaseInspector_Inspect(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				db.RegisterModel((*PublisherToJournalist)(nil))
 
-				dbInspector, err := sqlschema.NewInspector(db, migrationsTable, migrationLocksTable)
+				dbInspector, err := sqlschema.NewInspector(db, sqlschema.WithSchemaName(tt.schemaName), sqlschema.WithExcludeTables(migrationsTable, migrationLocksTable))
 				if err != nil {
 					t.Skip(err)
 				}
@@ -353,7 +353,7 @@ func TestDatabaseInspector_Inspect(t *testing.T) {
 					(*Article)(nil),               // references Journalist and Publisher
 				)
 
-				got, err := dbInspector.Inspect(ctx, tt.schemaName)
+				got, err := dbInspector.Inspect(ctx)
 				require.NoError(t, err)
 
 				// State.FKs store their database names, which differ from dialect to dialect.
@@ -523,7 +523,7 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 
 			tables := schema.NewTables(dialect)
 			tables.Register((*Model)(nil))
-			inspector := sqlschema.NewBunModelInspector(tables)
+			inspector := sqlschema.NewBunModelInspector(tables, sqlschema.WithSchemaName(dialect.DefaultSchema()))
 
 			want := orderedmap.New[string, sqlschema.Column](orderedmap.WithInitialData(
 				orderedmap.Pair[string, sqlschema.Column]{
@@ -542,7 +542,7 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 				},
 			))
 
-			got, err := inspector.Inspect(context.Background(), dialect.DefaultSchema())
+			got, err := inspector.Inspect(context.Background())
 			require.NoError(t, err)
 
 			gotTables := got.GetTables()
@@ -562,7 +562,7 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 
 			tables := schema.NewTables(dialect)
 			tables.Register((*Model)(nil))
-			inspector := sqlschema.NewBunModelInspector(tables)
+			inspector := sqlschema.NewBunModelInspector(tables, sqlschema.WithSchemaName(dialect.DefaultSchema()))
 
 			want := orderedmap.New[string, sqlschema.Column](orderedmap.WithInitialData(
 				orderedmap.Pair[string, sqlschema.Column]{
@@ -587,7 +587,7 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 				},
 			))
 
-			got, err := inspector.Inspect(context.Background(), dialect.DefaultSchema())
+			got, err := inspector.Inspect(context.Background())
 			require.NoError(t, err)
 
 			gotTables := got.GetTables()
@@ -606,7 +606,7 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 
 			tables := schema.NewTables(dialect)
 			tables.Register((*Model)(nil))
-			inspector := sqlschema.NewBunModelInspector(tables)
+			inspector := sqlschema.NewBunModelInspector(tables, sqlschema.WithSchemaName(dialect.DefaultSchema()))
 
 			want := &sqlschema.BaseTable{
 				Name: "models",
@@ -616,7 +616,7 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 				},
 			}
 
-			got, err := inspector.Inspect(context.Background(), dialect.DefaultSchema())
+			got, err := inspector.Inspect(context.Background())
 			require.NoError(t, err)
 
 			gotTables := got.GetTables()
@@ -635,10 +635,10 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 
 			tables := schema.NewTables(dialect)
 			tables.Register((*Model)(nil))
-			inspector := sqlschema.NewBunModelInspector(tables)
+			inspector := sqlschema.NewBunModelInspector(tables, sqlschema.WithSchemaName(dialect.DefaultSchema()))
 			want := sqlschema.NewColumns("id", "email")
 
-			got, err := inspector.Inspect(context.Background(), dialect.DefaultSchema())
+			got, err := inspector.Inspect(context.Background())
 			require.NoError(t, err)
 
 			gotTables := got.GetTables()
@@ -658,9 +658,9 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 
 			tables := schema.NewTables(dialect)
 			tables.Register((*Model)(nil))
-			inspector := sqlschema.NewBunModelInspector(tables)
+			inspector := sqlschema.NewBunModelInspector(tables, sqlschema.WithSchemaName("custom_schema"))
 
-			got, err := inspector.Inspect(context.Background(), "custom_schema")
+			got, err := inspector.Inspect(context.Background())
 			require.NoError(t, err)
 
 			gotTables := got.GetTables()
@@ -683,9 +683,9 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 
 			tables := schema.NewTables(dialect)
 			tables.Register((*KeepMe)(nil), (*LoseMe)(nil))
-			inspector := sqlschema.NewBunModelInspector(tables)
+			inspector := sqlschema.NewBunModelInspector(tables, sqlschema.WithSchemaName("want"))
 
-			got, err := inspector.Inspect(context.Background(), "want")
+			got, err := inspector.Inspect(context.Background())
 			require.NoError(t, err)
 
 			gotTables := got.GetTables()

--- a/internal/dbtest/inspect_test.go
+++ b/internal/dbtest/inspect_test.go
@@ -433,7 +433,7 @@ func cmpColumns(
 			continue
 		}
 
-		if !d.EquivalentType(wantCol, gotCol) {
+		if !d.CompareType(wantCol, gotCol) {
 			errorf("sql types are not equivalent:\n\t(+want)\t%s\n\t(-got)\t%s", formatType(wantCol), formatType(gotCol))
 		}
 

--- a/migrate/auto.go
+++ b/migrate/auto.go
@@ -155,7 +155,7 @@ func NewAutoMigrator(db *bun.DB, opts ...AutoMigratorOption) (*AutoMigrator, err
 		return nil, err
 	}
 	am.dbInspector = dbInspector
-	am.diffOpts = append(am.diffOpts, withTypeEquivalenceFunc(db.Dialect().(sqlschema.InspectorDialect).EquivalentType))
+	am.diffOpts = append(am.diffOpts, withCompareTypeFunc(db.Dialect().(sqlschema.InspectorDialect).CompareType))
 
 	dbMigrator, err := sqlschema.NewMigrator(db, am.schemaName)
 	if err != nil {

--- a/migrate/auto.go
+++ b/migrate/auto.go
@@ -27,6 +27,8 @@ func WithModel(models ...interface{}) AutoMigratorOption {
 // WithExcludeTable tells the AutoMigrator to ignore a table in the database.
 // This prevents AutoMigrator from dropping tables which may exist in the schema
 // but which are not used by the application.
+//
+// Do not exclude tables included via WithModel, as BunModelInspector ignores this setting.
 func WithExcludeTable(tables ...string) AutoMigratorOption {
 	return func(m *AutoMigrator) {
 		m.excludeTables = append(m.excludeTables, tables...)
@@ -148,7 +150,7 @@ func NewAutoMigrator(db *bun.DB, opts ...AutoMigratorOption) (*AutoMigrator, err
 	}
 	am.excludeTables = append(am.excludeTables, am.table, am.locksTable)
 
-	dbInspector, err := sqlschema.NewInspector(db, am.excludeTables...)
+	dbInspector, err := sqlschema.NewInspector(db, sqlschema.WithSchemaName(am.schemaName), sqlschema.WithExcludeTables(am.excludeTables...))
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +165,7 @@ func NewAutoMigrator(db *bun.DB, opts ...AutoMigratorOption) (*AutoMigrator, err
 
 	tables := schema.NewTables(db.Dialect())
 	tables.Register(am.includeModels...)
-	am.modelInspector = sqlschema.NewBunModelInspector(tables)
+	am.modelInspector = sqlschema.NewBunModelInspector(tables, sqlschema.WithSchemaName(am.schemaName))
 
 	return am, nil
 }
@@ -171,12 +173,12 @@ func NewAutoMigrator(db *bun.DB, opts ...AutoMigratorOption) (*AutoMigrator, err
 func (am *AutoMigrator) plan(ctx context.Context) (*changeset, error) {
 	var err error
 
-	got, err := am.dbInspector.Inspect(ctx, am.schemaName)
+	got, err := am.dbInspector.Inspect(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	want, err := am.modelInspector.Inspect(ctx, am.schemaName)
+	want, err := am.modelInspector.Inspect(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/migrate/sqlschema/inspector.go
+++ b/migrate/sqlschema/inspector.go
@@ -21,10 +21,10 @@ type InspectorDialect interface {
 	// Use ApplyInspectorOptions to reduce boilerplate.
 	NewInspector(db *bun.DB, options ...InspectorOption) Inspector
 
-	// EquivalentType returns true if col1 and co2 SQL types are equivalent,
+	// CompareType returns true if col1 and co2 SQL types are equivalent,
 	// i.e. they might use dialect-specifc type aliases (SERIAL ~ SMALLINT)
 	// or specify the same VARCHAR length differently (VARCHAR(255) ~ VARCHAR).
-	EquivalentType(Column, Column) bool
+	CompareType(Column, Column) bool
 }
 
 // InspectorConfig controls the scope of migration by limiting the objects Inspector should return.

--- a/migrate/sqlschema/inspector.go
+++ b/migrate/sqlschema/inspector.go
@@ -13,7 +13,13 @@ import (
 
 type InspectorDialect interface {
 	schema.Dialect
-	Inspector(db *bun.DB, excludeTables ...string) Inspector
+
+	// Inspector returns a new instance of Inspector for the dialect.
+	// Dialects MAY set their default InspectorConfig values in constructor
+	// but MUST apply InspectorOptions to ensure they can be overriden.
+	//
+	// Use ApplyInspectorOptions to reduce boilerplate.
+	Inspector(db *bun.DB, options ...InspectorOption) Inspector
 
 	// EquivalentType returns true if col1 and co2 SQL types are equivalent,
 	// i.e. they might use dialect-specifc type aliases (SERIAL ~ SMALLINT)
@@ -21,61 +27,77 @@ type InspectorDialect interface {
 	EquivalentType(Column, Column) bool
 }
 
-// Inspector reads schema state.
-type Inspector interface {
-	Inspect(ctx context.Context, schemaName string) (Database, error)
+// InspectorConfig controls the scope of migration by limiting the objects Inspector should return.
+// Inspectors SHOULD use the configuration directly instead of copying it, or MAY choose to embed it,
+// to make sure options are always applied correctly.
+type InspectorConfig struct {
+	// SchemaName limits inspection to tables in a particular schema.
+	SchemaName string
+
+	// ExcludeTables from inspection.
+	ExcludeTables []string
 }
 
-// inspector is opaque pointer to a databse inspector.
-type inspector struct {
-	Inspector
+// Inspector reads schema state.
+type Inspector interface {
+	Inspect(ctx context.Context) (Database, error)
+}
+
+func WithSchemaName(schemaName string) InspectorOption {
+	return func(cfg *InspectorConfig) {
+		cfg.SchemaName = schemaName
+	}
+}
+
+// WithExcludeTables works in append-only mode, i.e. tables cannot be re-included.
+func WithExcludeTables(tables ...string) InspectorOption {
+	return func(cfg *InspectorConfig) {
+		cfg.ExcludeTables = append(cfg.ExcludeTables, tables...)
+	}
 }
 
 // NewInspector creates a new database inspector, if the dialect supports it.
-func NewInspector(db *bun.DB, excludeTables ...string) (Inspector, error) {
+func NewInspector(db *bun.DB, options ...InspectorOption) (Inspector, error) {
 	dialect, ok := (db.Dialect()).(InspectorDialect)
 	if !ok {
 		return nil, fmt.Errorf("%s does not implement sqlschema.Inspector", db.Dialect().Name())
 	}
 	return &inspector{
-		Inspector: dialect.Inspector(db, excludeTables...),
+		Inspector: dialect.Inspector(db, options...),
 	}, nil
+}
+
+func NewBunModelInspector(tables *schema.Tables, options ...InspectorOption) *BunModelInspector {
+	bmi := &BunModelInspector{
+		tables: tables,
+	}
+	ApplyInspectorOptions(&bmi.InspectorConfig, options...)
+	return bmi
+}
+
+type InspectorOption func(*InspectorConfig)
+
+func ApplyInspectorOptions(cfg *InspectorConfig, options ...InspectorOption) {
+	for _, opt := range options {
+		opt(cfg)
+	}
+}
+
+// inspector is opaque pointer to a database inspector.
+type inspector struct {
+	Inspector
 }
 
 // BunModelInspector creates the current project state from the passed bun.Models.
 // Do not recycle BunModelInspector for different sets of models, as older models will not be de-registerred before the next run.
 type BunModelInspector struct {
+	InspectorConfig
 	tables *schema.Tables
 }
 
 var _ Inspector = (*BunModelInspector)(nil)
 
-func NewBunModelInspector(tables *schema.Tables) *BunModelInspector {
-	return &BunModelInspector{
-		tables: tables,
-	}
-}
-
-// BunModelSchema is the schema state derived from bun table models.
-type BunModelSchema struct {
-	BaseDatabase
-
-	Tables *orderedmap.OrderedMap[string, Table]
-}
-
-func (ms BunModelSchema) GetTables() *orderedmap.OrderedMap[string, Table] {
-	return ms.Tables
-}
-
-// BunTable provides additional table metadata that is only accessible from scanning bun models.
-type BunTable struct {
-	BaseTable
-
-	// Model stores the zero interface to the underlying Go struct.
-	Model interface{}
-}
-
-func (bmi *BunModelInspector) Inspect(ctx context.Context, schemaName string) (Database, error) {
+func (bmi *BunModelInspector) Inspect(ctx context.Context) (Database, error) {
 	state := BunModelSchema{
 		BaseDatabase: BaseDatabase{
 			ForeignKeys: make(map[ForeignKey]string),
@@ -83,7 +105,7 @@ func (bmi *BunModelInspector) Inspect(ctx context.Context, schemaName string) (D
 		Tables: orderedmap.New[string, Table](),
 	}
 	for _, t := range bmi.tables.All() {
-		if t.Schema != schemaName {
+		if t.Schema != bmi.SchemaName {
 			continue
 		}
 
@@ -197,4 +219,23 @@ func exprToLower(s string) string {
 		return s
 	}
 	return strings.ToLower(s)
+}
+
+// BunModelSchema is the schema state derived from bun table models.
+type BunModelSchema struct {
+	BaseDatabase
+
+	Tables *orderedmap.OrderedMap[string, Table]
+}
+
+func (ms BunModelSchema) GetTables() *orderedmap.OrderedMap[string, Table] {
+	return ms.Tables
+}
+
+// BunTable provides additional table metadata that is only accessible from scanning bun models.
+type BunTable struct {
+	BaseTable
+
+	// Model stores the zero interface to the underlying Go struct.
+	Model interface{}
 }

--- a/migrate/sqlschema/inspector.go
+++ b/migrate/sqlschema/inspector.go
@@ -19,7 +19,7 @@ type InspectorDialect interface {
 	// but MUST apply InspectorOptions to ensure they can be overriden.
 	//
 	// Use ApplyInspectorOptions to reduce boilerplate.
-	Inspector(db *bun.DB, options ...InspectorOption) Inspector
+	NewInspector(db *bun.DB, options ...InspectorOption) Inspector
 
 	// EquivalentType returns true if col1 and co2 SQL types are equivalent,
 	// i.e. they might use dialect-specifc type aliases (SERIAL ~ SMALLINT)
@@ -63,7 +63,7 @@ func NewInspector(db *bun.DB, options ...InspectorOption) (Inspector, error) {
 		return nil, fmt.Errorf("%s does not implement sqlschema.Inspector", db.Dialect().Name())
 	}
 	return &inspector{
-		Inspector: dialect.Inspector(db, options...),
+		Inspector: dialect.NewInspector(db, options...),
 	}, nil
 }
 

--- a/migrate/sqlschema/migrator.go
+++ b/migrate/sqlschema/migrator.go
@@ -9,7 +9,7 @@ import (
 
 type MigratorDialect interface {
 	schema.Dialect
-	Migrator(db *bun.DB, schemaName string) Migrator
+	NewMigrator(db *bun.DB, schemaName string) Migrator
 }
 
 type Migrator interface {
@@ -27,7 +27,7 @@ func NewMigrator(db *bun.DB, schemaName string) (Migrator, error) {
 		return nil, fmt.Errorf("%q dialect does not implement sqlschema.Migrator", db.Dialect().Name())
 	}
 	return &migrator{
-		Migrator: md.Migrator(db, schemaName),
+		Migrator: md.NewMigrator(db, schemaName),
 	}, nil
 }
 


### PR DESCRIPTION
This PR is a follow-up with some changes I overlooked in #926:

- Rename `Inspector -> NewInspector()` and `Migrator -> NewMigrator()`
- Configure `schemaName` and `excludeTables` with `InspectorOptions`
- Rename `EquivalentType() -> CompareType()`

> Looks like we can now remove (Dialect) DefaultSchema()

While every dialect is able to set its own default schema internally, AutoMigrator needs to pass a set this for BunModelInspector explicitly.