### PR TITLE
:bug: AutoMigrator: Do not create migrations if nothing to migrate

### DIFF
--- a/internal/dbtest/inspect_test.go
+++ b/internal/dbtest/inspect_test.go
@@ -537,7 +537,7 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 					Key: "name",
 					Value: &sqlschema.BaseColumn{
 						SQLType:      sqltype.VarChar,
-						DefaultValue: "'John Doe'",
+						DefaultValue: "John Doe",
 					},
 				},
 			))

--- a/migrate/auto.go
+++ b/migrate/auto.go
@@ -217,7 +217,7 @@ func (am *AutoMigrator) Migrate(ctx context.Context, opts ...MigrationOption) (*
 // CreateSQLMigration writes required changes to a new migration file.
 // Use migrate.Migrator to apply the generated migrations.
 func (am *AutoMigrator) CreateSQLMigrations(ctx context.Context) ([]*MigrationFile, error) {
-	_, files, err := am.createSQLMigrations(ctx, true)
+	_, files, err := am.createSQLMigrations(ctx, false)
 	if err == errNothingToMigrate {
 		return files, nil
 	}
@@ -227,7 +227,7 @@ func (am *AutoMigrator) CreateSQLMigrations(ctx context.Context) ([]*MigrationFi
 // CreateTxSQLMigration writes required changes to a new migration file making sure they will be executed
 // in a transaction when applied. Use migrate.Migrator to apply the generated migrations.
 func (am *AutoMigrator) CreateTxSQLMigrations(ctx context.Context) ([]*MigrationFile, error) {
-	_, files, err := am.createSQLMigrations(ctx, false)
+	_, files, err := am.createSQLMigrations(ctx, true)
 	if err == errNothingToMigrate {
 		return files, nil
 	}

--- a/migrate/auto.go
+++ b/migrate/auto.go
@@ -196,6 +196,9 @@ func (am *AutoMigrator) plan(ctx context.Context) (*changeset, error) {
 func (am *AutoMigrator) Migrate(ctx context.Context, opts ...MigrationOption) (*MigrationGroup, error) {
 	migrations, _, err := am.createSQLMigrations(ctx, false)
 	if err != nil {
+		if err == errNothingToMigrate {
+			return new(MigrationGroup), nil
+		}
 		return nil, fmt.Errorf("auto migrate: %w", err)
 	}
 
@@ -215,6 +218,9 @@ func (am *AutoMigrator) Migrate(ctx context.Context, opts ...MigrationOption) (*
 // Use migrate.Migrator to apply the generated migrations.
 func (am *AutoMigrator) CreateSQLMigrations(ctx context.Context) ([]*MigrationFile, error) {
 	_, files, err := am.createSQLMigrations(ctx, true)
+	if err == errNothingToMigrate {
+		return files, nil
+	}
 	return files, err
 }
 
@@ -222,13 +228,24 @@ func (am *AutoMigrator) CreateSQLMigrations(ctx context.Context) ([]*MigrationFi
 // in a transaction when applied. Use migrate.Migrator to apply the generated migrations.
 func (am *AutoMigrator) CreateTxSQLMigrations(ctx context.Context) ([]*MigrationFile, error) {
 	_, files, err := am.createSQLMigrations(ctx, false)
+	if err == errNothingToMigrate {
+		return files, nil
+	}
 	return files, err
 }
+
+// errNothingToMigrate is a sentinel error which means the database is already in a desired state.
+// Should not be returned to the user -- return a nil-error instead.
+var errNothingToMigrate = errors.New("nothing to migrate")
 
 func (am *AutoMigrator) createSQLMigrations(ctx context.Context, transactional bool) (*Migrations, []*MigrationFile, error) {
 	changes, err := am.plan(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("create sql migrations: %w", err)
+	}
+
+	if changes.Len() == 0 {
+		return nil, nil, errNothingToMigrate
 	}
 
 	name, _ := genMigrationName(am.schemaName + "_auto")
@@ -280,6 +297,10 @@ func (am *AutoMigrator) createSQL(_ context.Context, migrations *Migrations, fna
 		Content: string(content),
 	}
 	return mf, nil
+}
+
+func (c *changeset) Len() int {
+	return len(c.operations)
 }
 
 // Func creates a MigrationFunc that applies all operations all the changeset.

--- a/migrate/sqlschema/inspector.go
+++ b/migrate/sqlschema/inspector.go
@@ -120,7 +120,7 @@ func (bmi *BunModelInspector) Inspect(ctx context.Context) (Database, error) {
 				Name:            f.Name,
 				SQLType:         strings.ToLower(sqlType), // TODO(dyma): maybe this is not necessary after Column.Eq()
 				VarcharLen:      length,
-				DefaultValue:    exprToLower(f.SQLDefault),
+				DefaultValue:    exprOrLiteral(f.SQLDefault),
 				IsNullable:      !f.NotNull,
 				IsAutoIncrement: f.AutoIncrement,
 				IsIdentity:      f.Identity,
@@ -211,12 +211,13 @@ func parseLen(typ string) (string, int, error) {
 	return typ[:paren], length, nil
 }
 
-// exprToLower converts string to lowercase, if it does not contain a string literal 'lit'.
+// exprOrLiteral converts string to lowercase, if it does not contain a string literal 'lit'
+// and trims the surrounding '' otherwise.
 // Use it to ensure that user-defined default values in the models are always comparable
 // to those returned by the database inspector, regardless of the case convention in individual drivers.
-func exprToLower(s string) string {
+func exprOrLiteral(s string) string {
 	if strings.HasPrefix(s, "'") && strings.HasSuffix(s, "'") {
-		return s
+		return strings.Trim(s, "'")
 	}
 	return strings.ToLower(s)
 }


### PR DESCRIPTION
While working on #1062 I noticed that AutoMigrator would create migration files and DB entries even when models haven't been updated and there isn't anything to migrate. This PR addresses this issue.

It also mistakenly puts _non-transactional_ migrations in `.tx.sql` files and vice versa because of a wrong value being passed to `createSQLMigrations`.

Finally, BunModelInspector should drop surrounding `''` from string literals in `bun:"default:'John Doe'"` to make the value comparable to the value retrieved from the database, i.e. a Go-string `"John Doe"`. 