### PR TITLE
ci: mssql use custom certificate to avoid negative serial number error

### DIFF
--- a/internal/dbtest/docker-compose.yaml
+++ b/internal/dbtest/docker-compose.yaml
@@ -57,10 +57,10 @@ services:
       interval: 10s
       retries: 3
   mssql:
-    image: mcmoe/mssqldocker:v2019.CU4.0
+    image: mssql-local
     environment:
       - ACCEPT_EULA=Y
-      - SA_PASSWORD=passWORD1
+      - MSSQL_SA_PASSWORD=passWORD1
       - MSSQL_DB=test
       - MSSQL_USER=sa
       - MSSQL_PASSWORD=passWORD1

--- a/internal/dbtest/mssql-docker/Dockerfile
+++ b/internal/dbtest/mssql-docker/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/mssql/server:2019-CU29-ubuntu-20.04
+
+RUN openssl req -x509 -nodes -newkey rsa:2048 -subj '/CN=mssql' -addext "subjectAltName = DNS:mssql" -keyout /etc/ssl/private/mssql.key -out /etc/ssl/certs/mssql.pem -days 7
+RUN chmod 400 /etc/ssl/private/mssql.key
+RUN chmod 400 /etc/ssl/certs/mssql.pem
+RUN mkdir -p /var/opt/mssql
+COPY mssql.conf /var/opt/mssql/mssql.conf
+
+
+# Create a config directory
+RUN mkdir -p /usr/config
+WORKDIR /usr/config
+
+# Bundle config source
+COPY . /usr/config
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/internal/dbtest/mssql-docker/configure-db.sh
+++ b/internal/dbtest/mssql-docker/configure-db.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Wait 60 seconds for SQL Server to start up by ensuring that 
+# calling SQLCMD does not return an error code, which will ensure that sqlcmd is accessible
+# and that system and user databases return "0" which means all databases are in an "online" state
+# https://docs.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-databases-transact-sql?view=sql-server-2017 
+
+DBSTATUS=1
+ERRCODE=1
+i=0
+
+while [[ $DBSTATUS -ne 0 ]] && [[ $i -lt 60 ]] && [[ $ERRCODE -ne 0 ]]; do
+	i=$i+1
+	DBSTATUS=$(/opt/mssql-tools/bin/sqlcmd -h -1 -t 1 -U sa -P $MYSQL_SA_PASSWORD -Q "SET NOCOUNT ON; Select SUM(state) from sys.databases")
+	ERRCODE=$?
+	sleep 1
+done
+
+if [ $DBSTATUS -ne 0 ] OR [ $ERRCODE -ne 0 ]; then 
+	echo "SQL Server took more than 60 seconds to start up or one or more databases are not in an ONLINE state"
+	exit 1
+fi
+
+# Run the setup script to create the DB and the schema in the DB
+/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P $MYSQL_SA_PASSWORD -d master -i setup.sql

--- a/internal/dbtest/mssql-docker/entrypoint.sh
+++ b/internal/dbtest/mssql-docker/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Start the script to create the DB and user
+/usr/config/configure-db.sh &
+
+# Start SQL Server
+/opt/mssql/bin/sqlservr

--- a/internal/dbtest/mssql-docker/mssql.conf
+++ b/internal/dbtest/mssql-docker/mssql.conf
@@ -1,0 +1,5 @@
+[network]
+tlscert = /etc/ssl/certs/mssql.pem
+tlskey = /etc/ssl/private/mssql.key
+tlsprotocols = 1.2
+forceencryption = 1

--- a/internal/dbtest/mssql-docker/setup.sql
+++ b/internal/dbtest/mssql-docker/setup.sql
@@ -1,0 +1,8 @@
+/*
+
+Enter custom T-SQL here that would run after SQL Server has started up. 
+
+*/
+
+CREATE DATABASE $(MSSQL_DB);
+GO

--- a/internal/dbtest/test.sh
+++ b/internal/dbtest/test.sh
@@ -1,4 +1,7 @@
 #!/bin/sh -eux
+cd mssql-docker
+docker build -t mssql-local .
+cd ..
 trap 'docker-compose down -v' EXIT
 docker-compose down -v
 docker-compose up -d


### PR DESCRIPTION
To fix error:
```shell
        --- FAIL: TestSoftDelete/mssql2019/testSoftDeleteForce (0.00s)
            db_test.go:1780: 
                	Error Trace:	/home/runner/work/bun/bun/internal/dbtest/db_test.go:1780
                	            				/home/runner/work/bun/bun/internal/dbtest/soft_delete_test.go:106
                	            				/home/runner/work/bun/bun/internal/dbtest/soft_delete_test.go:28
                	Error:      	Received unexpected error:
                	            	TLS Handshake failed: tls: failed to parse certificate from server: x509: negative serial number
                	Test:       	TestSoftDelete/mssql2019/testSoftDeleteForce
                	Messages:   	must reset model
```