### PR TITLE
Fix: Removed unused param on table.go and tables.go: canAddr

### DIFF
--- a/schema/table.go
+++ b/schema/table.go
@@ -75,7 +75,7 @@ type structField struct {
 	Table *Table
 }
 
-func (table *Table) init(dialect Dialect, typ reflect.Type, canAddr bool) {
+func (table *Table) init(dialect Dialect, typ reflect.Type) {
 	table.dialect = dialect
 	table.Type = typ
 	table.ZeroValue = reflect.New(table.Type).Elem()
@@ -90,7 +90,7 @@ func (table *Table) init(dialect Dialect, typ reflect.Type, canAddr bool) {
 
 	table.Fields = make([]*Field, 0, typ.NumField())
 	table.FieldMap = make(map[string]*Field, typ.NumField())
-	table.processFields(typ, canAddr)
+	table.processFields(typ)
 
 	hooks := []struct {
 		typ  reflect.Type
@@ -110,7 +110,7 @@ func (table *Table) init(dialect Dialect, typ reflect.Type, canAddr bool) {
 	}
 }
 
-func (t *Table) processFields(typ reflect.Type, canAddr bool) {
+func (t *Table) processFields(typ reflect.Type) {
 	type embeddedField struct {
 		prefix     string
 		index      []int

--- a/schema/tables.go
+++ b/schema/tables.go
@@ -72,7 +72,7 @@ func (t *Tables) InProgress(typ reflect.Type) *Table {
 
 	table := new(Table)
 	t.inProgress[typ] = table
-	table.init(t.dialect, typ, false)
+	table.init(t.dialect, typ)
 
 	return table
 }


### PR DESCRIPTION
Hi, I found the parameter `canAddr` in `table.go`. It's passed as false during the initialization of `table.init` here:

````go
func (t *Tables) InProgress(typ reflect.Type) *Table {
	if table, ok := t.inProgress[typ]; ok {
		return table
	}

	table := new(Table)
	t.inProgress[typ] = table
	table.init(t.dialect, typ, false)

	return table
}
````

````go
func (table *Table) init(dialect Dialect, typ reflect.Type, canAddr bool) {
	table.dialect = dialect
	table.Type = typ
	table.ZeroValue = reflect.New(table.Type).Elem()
	table.ZeroIface = reflect.New(table.Type).Interface()
	table.TypeName = internal.ToExported(table.Type.Name())
	table.ModelName = internal.Underscore(table.Type.Name())
	tableName := tableNameInflector(table.ModelName)
	table.setName(tableName)
	table.Alias = table.ModelName
	table.SQLAlias = table.quoteIdent(table.ModelName)
	table.Schema = dialect.DefaultSchema()

	table.Fields = make([]*Field, 0, typ.NumField())
	table.FieldMap = make(map[string]*Field, typ.NumField())
	table.processFields(typ, canAddr)

````

This parameter is simply passed along to the `table.processFields(typ, canAddr) `function, but it’s never actually used inside that function. Based on this, I went ahead and removed it. If there are any plans to use this in the future, please feel free to close this PR or let me know.