### PR TITLE
fix: replace the link to docs repo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,4 +31,4 @@ TAG=v1.0.0 ./scripts/tag.sh
 
 ## Documentation
 
-To contribute to the docs visit https://github.com/go-bun/bun-docs
+To contribute to the docs visit https://github.com/uptrace/bun-docs


### PR DESCRIPTION
Thank you for creating and maintaining such an excellent library!

This pull request fixes [the incorrect link](https://github.com/go-bun/bun-docs) in the CONTRIBUTING.md file.
