### PR TITLE
Add RelationWithOpts to SelectQuery for Customizing JOIN ON Clause

### DIFF
--- a/relation_join.go
+++ b/relation_join.go
@@ -16,6 +16,8 @@ type relationJoin struct {
 	JoinModel TableModel
 	Relation  *schema.Relation
 
+	additionalJoinOnConditions []schema.QueryWithArgs
+
 	apply   func(*SelectQuery) *SelectQuery
 	columns []schema.QueryWithArgs
 }
@@ -86,6 +88,11 @@ func (j *relationJoin) manyQueryCompositeIn(where []byte, q *SelectQuery) *Selec
 		j.Relation.BasePKs,
 	)
 	where = append(where, ")"...)
+	if len(j.additionalJoinOnConditions) > 0 {
+		where = append(where, " AND "...)
+		where = appendAdditionalJoinOnConditions(q.db.Formatter(), where, j.additionalJoinOnConditions)
+	}
+
 	q = q.Where(internal.String(where))
 
 	if j.Relation.PolymorphicField != nil {
@@ -110,6 +117,10 @@ func (j *relationJoin) manyQueryMulti(where []byte, q *SelectQuery) *SelectQuery
 	)
 
 	q = q.Where(internal.String(where))
+
+	if len(j.additionalJoinOnConditions) > 0 {
+		q = q.Where(internal.String(appendAdditionalJoinOnConditions(q.db.Formatter(), []byte{}, j.additionalJoinOnConditions)))
+	}
 
 	if j.Relation.PolymorphicField != nil {
 		q = q.Where("? = ?", j.Relation.PolymorphicField.SQLName, j.Relation.PolymorphicValue)
@@ -204,6 +215,12 @@ func (j *relationJoin) m2mQuery(q *SelectQuery) *SelectQuery {
 	join = append(join, ") IN ("...)
 	join = appendChildValues(fmter, join, j.BaseModel.rootValue(), index, j.Relation.BasePKs)
 	join = append(join, ")"...)
+
+	if len(j.additionalJoinOnConditions) > 0 {
+		join = append(join, " AND "...)
+		join = appendAdditionalJoinOnConditions(fmter, join, j.additionalJoinOnConditions)
+	}
+
 	q = q.Join(internal.String(join))
 
 	joinTable := j.JoinModel.Table()
@@ -330,6 +347,11 @@ func (j *relationJoin) appendHasOneJoin(
 		b = j.appendSoftDelete(fmter, b, q.flags)
 	}
 
+	if len(j.additionalJoinOnConditions) > 0 {
+		b = append(b, " AND "...)
+		b = appendAdditionalJoinOnConditions(fmter, b, j.additionalJoinOnConditions)
+	}
+
 	return b, nil
 }
 
@@ -415,5 +437,17 @@ func appendMultiValues(
 		b = b[:len(b)-6] // trim ") OR ("
 	}
 	b = append(b, ')')
+	return b
+}
+
+func appendAdditionalJoinOnConditions(
+	fmter schema.Formatter, b []byte, conditions []schema.QueryWithArgs,
+) []byte {
+	for i, cond := range conditions {
+		if i > 0 {
+			b = append(b, " AND "...)
+		}
+		b = fmter.AppendQuery(b, cond.Query, cond.Args...)
+	}
 	return b
 }


### PR DESCRIPTION
## Description
Closes https://github.com/uptrace/bun/issues/554.

This PR introduces a new method, RelationWithOpts, to the SelectQuery interface. This method allows users to customize the JOIN ON clause when defining relationships between models (e.g., has-one, has-many).

## Key Points of Discussion

Current Behavior: The existing Relation method allows applying filters to the joined table's SELECT query but does not modify the JOIN ON clause. For example(it is on https://github.com/uptrace/bun/issues/554):

```go
q := repo.db.NewSelect().Model(&product)
q.Relation("Stock", func(q *bun.SelectQuery) *bun.SelectQuery {
    return q.Where("branch_id = ?", filter.BranchId)
})
```

- I believe it's essential to preserve this behavior to maintain backward compatibility and separation of concerns (filtering the joined table vs. customizing JOIN ON).
- Proposed Changes: The RelationWithOpts method provides an additional option to customize the JOIN ON clause while keeping the existing functionality of Relation.

## Example Usage

Here is a quick example of how RelationWithOpts can be utilized:

```go
q := repo.db.NewSelect().Model(&product)
q.RelationWithOpts("Stock", &bun.RelationOpts{
	AdditionalJoinOnConditions: []schema.QueryWithArgs{
		{
			Query: "stock.quantity = ?",
			Args:  []any{1},
		},
	},
})
```

I add this feature but actually i don't like this feature itself and the interface very much (especially, i don't like to directly face `[]schema.QueryWithArgs`). Feedback and suggestions for improving the interface and functionality are welcome. Let me know your thoughts! (If this feature is deemed unnecessary, please feel free to close this pull request without hesitation.)
