### PR TITLE
fix: get m2m table's structKey with driver.Valuer

### DIFF
--- a/model_table_m2m.go
+++ b/model_table_m2m.go
@@ -103,7 +103,7 @@ func (m *m2mModel) scanM2MColumn(column string, src interface{}) error {
 			if err := field.Scan(dest, src); err != nil {
 				return err
 			}
-			m.structKey = append(m.structKey, dest.Interface())
+			m.structKey = append(m.structKey, indirectFieldValue(dest))
 			break
 		}
 	}


### PR DESCRIPTION
Close #1100