### PR TITLE
feat: downgrade to use the field in has-many-relation

### DIFF
--- a/model_table_m2m.go
+++ b/model_table_m2m.go
@@ -103,7 +103,7 @@ func (m *m2mModel) scanM2MColumn(column string, src interface{}) error {
 			if err := field.Scan(dest, src); err != nil {
 				return err
 			}
-			m.structKey = append(m.structKey, indirectFieldValue(dest))
+			m.structKey = append(m.structKey, indirectAsKey(dest))
 			break
 		}
 	}


### PR DESCRIPTION
Even if driver.Valuer is implemented, we will still directly use the field if the returned value is not suitable as a map key.

Close #1107

#1080 introduced some new features but also broke the functionality of some existing code.
To ensure compatibility, I added this *strange* logic.