### PR TITLE
feat(bunotel): Ability to override span names

### DIFF
--- a/extra/bunotel/option.go
+++ b/extra/bunotel/option.go
@@ -1,6 +1,7 @@
 package bunotel
 
 import (
+	"github.com/uptrace/bun"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
@@ -30,6 +31,14 @@ func WithDBName(name string) Option {
 func WithFormattedQueries(format bool) Option {
 	return func(h *QueryHook) {
 		h.formatQueries = format
+	}
+}
+
+// WithSpanNameFormatter takes a function that determines the span name
+// for a given query event.
+func WithSpanNameFormatter(f func(*bun.QueryEvent) string) Option {
+	return func(h *QueryHook) {
+		h.spanNameFormatter = f
 	}
 }
 


### PR DESCRIPTION
Bun OTEL spans would be much more informative in APM tools if their name included the primary table being queried. This could be added easily enough, however it might be nice to follow the convention used in other popular middlewares like `otelhttp` by adding a `WithSpanNameFormatter` option.

This PR allows me to add the primary query table to span names like so:
```golang
bunotel.NewQueryHook(bunotel.WithSpanNameFormatter(func(event *bun.QueryEvent) string {
	name := event.Operation()
	if event.IQuery != nil {
		if tableName := event.IQuery.GetTableName(); tableName != "" {
			name += " " + tableName
		}
	}
	return name
}))
```