### PR TITLE
chore(ci): Update Go version matrix in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.23.x, 1.24.x]
+        go-version: [1.22.x, 1.23.x, 1.24.x]
 
     services:
       postgres:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.22.x, 1.23.x]
+        go-version: [1.23.x, 1.24.x]
 
     services:
       postgres:


### PR DESCRIPTION
Update the Go version matrix in the build workflow to include Go 1.24. This ensures that the project is tested against the latest supported Go versions.