### PR TITLE
chore: move ReadWriteConnResolver to bunexp

### DIFF
--- a/db.go
+++ b/db.go
@@ -6,11 +6,9 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
-	"math/rand/v2"
 	"reflect"
 	"strings"
 	"sync/atomic"
-	"time"
 
 	"github.com/uptrace/bun/dialect/feature"
 	"github.com/uptrace/bun/internal"
@@ -40,6 +38,12 @@ func WithDiscardUnknownColumns() DBOption {
 	return func(db *DB) {
 		db.flags = db.flags.Set(discardUnknownColumns)
 	}
+}
+
+// ConnResolver enables routing queries to multiple databases.
+type ConnResolver interface {
+	ResolveConn(query Query) IConn
+	Close() error
 }
 
 func WithConnResolver(resolver ConnResolver) DBOption {
@@ -740,131 +744,6 @@ func (tx Tx) NewDropColumn() *DropColumnQuery {
 	return NewDropColumnQuery(tx.db).Conn(tx)
 }
 
-//------------------------------------------------------------------------------
-
 func (db *DB) makeQueryBytes() []byte {
 	return internal.MakeQueryBytes()
-}
-
-//------------------------------------------------------------------------------
-
-// ConnResolver enables routing queries to multiple databases.
-type ConnResolver interface {
-	ResolveConn(query Query) IConn
-	Close() error
-}
-
-type DBReplica interface {
-	IConn
-	PingContext(context.Context) error
-	Close() error
-}
-
-// TODO:
-//   - make monitoring interval configurable
-//   - make ping timeout configutable
-//   - allow adding read/write replicas for multi-master replication
-type ReadWriteConnResolver struct {
-	replicas        []DBReplica // read-only replicas
-	healthyReplicas atomic.Pointer[[]DBReplica]
-	nextReplica     atomic.Int64
-	closed          atomic.Bool
-}
-
-func NewReadWriteConnResolver(opts ...ReadWriteConnResolverOption) *ReadWriteConnResolver {
-	r := new(ReadWriteConnResolver)
-
-	for _, opt := range opts {
-		opt(r)
-	}
-
-	if len(r.replicas) > 0 {
-		r.healthyReplicas.Store(&r.replicas)
-		go r.monitor()
-
-		// Start with a random replica.
-		rnd := rand.IntN(len(r.replicas))
-		r.nextReplica.Store(int64(rnd))
-	}
-
-	return r
-}
-
-type ReadWriteConnResolverOption func(r *ReadWriteConnResolver)
-
-func WithReadOnlyReplica(dbs ...DBReplica) ReadWriteConnResolverOption {
-	return func(r *ReadWriteConnResolver) {
-		r.replicas = append(r.replicas, dbs...)
-	}
-}
-
-func (r *ReadWriteConnResolver) Close() error {
-	if r.closed.Swap(true) {
-		return nil
-	}
-
-	var firstErr error
-	for _, db := range r.replicas {
-		if err := db.Close(); err != nil && firstErr == nil {
-			firstErr = err
-		}
-	}
-	return firstErr
-}
-
-// healthyReplica returns a random healthy replica.
-func (r *ReadWriteConnResolver) ResolveConn(query Query) IConn {
-	if len(r.replicas) == 0 || !isReadOnlyQuery(query) {
-		return nil
-	}
-
-	replicas := r.loadHealthyReplicas()
-	if len(replicas) == 0 {
-		return nil
-	}
-	if len(replicas) == 1 {
-		return replicas[0]
-	}
-	i := r.nextReplica.Add(1)
-	return replicas[int(i)%len(replicas)]
-}
-
-func isReadOnlyQuery(query Query) bool {
-	sel, ok := query.(*SelectQuery)
-	if !ok {
-		return false
-	}
-	for _, el := range sel.with {
-		if !isReadOnlyQuery(el.query) {
-			return false
-		}
-	}
-	return true
-}
-
-func (r *ReadWriteConnResolver) loadHealthyReplicas() []DBReplica {
-	if ptr := r.healthyReplicas.Load(); ptr != nil {
-		return *ptr
-	}
-	return nil
-}
-
-func (r *ReadWriteConnResolver) monitor() {
-	const interval = 5 * time.Second
-	for !r.closed.Load() {
-		healthy := make([]DBReplica, 0, len(r.replicas))
-
-		for _, replica := range r.replicas {
-			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-			err := replica.PingContext(ctx)
-			cancel()
-
-			if err == nil {
-				healthy = append(healthy, replica)
-			}
-		}
-
-		r.healthyReplicas.Store(&healthy)
-		time.Sleep(interval)
-	}
 }

--- a/extra/bunexp/resolver.go
+++ b/extra/bunexp/resolver.go
@@ -1,0 +1,178 @@
+package bunexp
+
+import (
+	"context"
+	"math/rand/v2"
+	"sync/atomic"
+	"time"
+
+	"github.com/uptrace/bun"
+)
+
+type DBReplica interface {
+	bun.IConn
+	PingContext(context.Context) error
+	Close() error
+}
+
+type DBReplicaRole int
+
+const (
+	DBReplicaReadOnly DBReplicaRole = 1 << iota
+	DBReplicaBackup
+)
+
+// TODO:
+//   - make monitoring interval configurable
+//   - make ping timeout configutable
+//   - allow adding read/write replicas for multi-master replication
+type ReadWriteConnResolver struct {
+	rw     replicas // for read-write queries
+	ro     replicas // for read-only queries
+	closed atomic.Bool
+}
+
+func NewReadWriteConnResolver(opts ...ReadWriteConnResolverOption) *ReadWriteConnResolver {
+	r := new(ReadWriteConnResolver)
+
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	r.rw.startMonitoring(&r.closed)
+	r.ro.startMonitoring(&r.closed)
+
+	return r
+}
+
+type ReadWriteConnResolverOption func(r *ReadWriteConnResolver)
+
+func WithDBReplica(db DBReplica, roles ...DBReplicaRole) ReadWriteConnResolverOption {
+	var role DBReplicaRole
+	for _, r := range roles {
+		role |= r
+	}
+
+	return func(r *ReadWriteConnResolver) {
+		if role&DBReplicaReadOnly == 0 {
+			r.rw.add(db, role)
+		}
+		r.ro.add(db, role)
+	}
+}
+
+func (r *ReadWriteConnResolver) Close() error {
+	if r.closed.Swap(true) {
+		return nil
+	}
+	var firstErr error
+	if err := r.rw.close(); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	if err := r.ro.close(); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
+}
+
+func (r *ReadWriteConnResolver) ResolveConn(query bun.Query) bun.IConn {
+	readOnly := bun.IsReadOnlyQuery(query)
+
+	var replicas []replica
+	if readOnly {
+		replicas = r.ro.healthyReplicas()
+	} else {
+		replicas = r.rw.healthyReplicas()
+	}
+
+	switch len(replicas) {
+	case 0:
+		return nil
+	case 1:
+		return replicas[0].DBReplica
+	}
+
+	var i int
+	if readOnly {
+		i = int(r.ro.next.Add(1))
+	} else {
+		i = int(r.rw.next.Add(1))
+	}
+	return replicas[i%len(replicas)]
+}
+
+type replicas struct {
+	replicas []replica // read-only replicas
+	healthy  atomic.Pointer[[]replica]
+	next     atomic.Int64
+}
+
+type replica struct {
+	DBReplica
+	roles DBReplicaRole
+}
+
+func (r *replicas) add(db DBReplica, roles DBReplicaRole) {
+	r.replicas = append(r.replicas, replica{
+		DBReplica: db,
+		roles:     roles,
+	})
+}
+
+func (r *replicas) healthyReplicas() []replica {
+	if ptr := r.healthy.Load(); ptr != nil {
+		return *ptr
+	}
+	return nil
+}
+
+func (r *replicas) close() error {
+	var firstErr error
+	for _, db := range r.replicas {
+		if err := db.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (r *replicas) startMonitoring(closed *atomic.Bool) {
+	if len(r.replicas) == 0 {
+		return
+	}
+
+	r.healthy.Store(&r.replicas)
+	go r.monitor(closed)
+
+	// Start with a random replica.
+	rnd := rand.IntN(len(r.replicas))
+	r.next.Store(int64(rnd))
+}
+
+func (r *replicas) monitor(closed *atomic.Bool) {
+	const interval = 5 * time.Second
+	for !closed.Load() {
+		healthy := make([]replica, 0, len(r.replicas))
+
+		for _, replica := range r.replicas {
+			if replica.roles&DBReplicaBackup != 0 {
+				continue
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			err := replica.PingContext(ctx)
+			cancel()
+
+			if err == nil {
+				healthy = append(healthy, replica)
+			}
+		}
+
+		if len(healthy) == 0 {
+			healthy = r.replicas
+		}
+
+		r.healthy.Store(&healthy)
+		time.Sleep(interval)
+	}
+}

--- a/internal/dbtest/db_test.go
+++ b/internal/dbtest/db_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/uptrace/bun/driver/pgdriver"
 	"github.com/uptrace/bun/driver/sqliteshim"
 	"github.com/uptrace/bun/extra/bundebug"
+	"github.com/uptrace/bun/extra/bunexp"
 	"github.com/uptrace/bun/schema"
 
 	_ "github.com/denisenkom/go-mssqldb"
@@ -1862,7 +1863,10 @@ func TestConnResolver(t *testing.T) {
 		require.NoError(t, rodb.Close())
 	})
 
-	resolver := bun.NewReadWriteConnResolver(bun.WithReadOnlyReplica(rodb))
+	resolver := bunexp.NewReadWriteConnResolver(
+		//bunexp.WithDBReplica(rwdb),
+		bunexp.WithDBReplica(rodb, bunexp.DBReplicaReadOnly),
+	)
 
 	db := bun.NewDB(rwdb, pgdialect.New(), bun.WithConnResolver(resolver))
 	db.AddQueryHook(bundebug.NewQueryHook(

--- a/query_base.go
+++ b/query_base.go
@@ -1475,3 +1475,16 @@ func (q *orderLimitOffsetQuery) appendLimitOffset(fmter schema.Formatter, b []by
 
 	return b, nil
 }
+
+func IsReadOnlyQuery(query Query) bool {
+	sel, ok := query.(*SelectQuery)
+	if !ok {
+		return false
+	}
+	for _, el := range sel.with {
+		if !IsReadOnlyQuery(el.query) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
I need to make another backwards incompatible change to ReadWriteConnResolver and probably will need to make more changes before the resolver is stable. The suggested solution is to move the resolver to a new package that can be changed independently from bun.