### PR TITLE
chore: standardize behind error setting method

### DIFF
--- a/query_delete.go
+++ b/query_delete.go
@@ -127,7 +127,7 @@ func (q *DeleteQuery) WhereAllWithDeleted() *DeleteQuery {
 
 func (q *DeleteQuery) Order(orders ...string) *DeleteQuery {
 	if !q.hasFeature(feature.DeleteOrderLimit) {
-		q.err = feature.NewNotSupportError(feature.DeleteOrderLimit)
+		q.setErr(feature.NewNotSupportError(feature.DeleteOrderLimit))
 		return q
 	}
 	q.addOrder(orders...)
@@ -136,7 +136,7 @@ func (q *DeleteQuery) Order(orders ...string) *DeleteQuery {
 
 func (q *DeleteQuery) OrderExpr(query string, args ...interface{}) *DeleteQuery {
 	if !q.hasFeature(feature.DeleteOrderLimit) {
-		q.err = feature.NewNotSupportError(feature.DeleteOrderLimit)
+		q.setErr(feature.NewNotSupportError(feature.DeleteOrderLimit))
 		return q
 	}
 	q.addOrderExpr(query, args...)
@@ -151,7 +151,7 @@ func (q *DeleteQuery) ForceDelete() *DeleteQuery {
 // ------------------------------------------------------------------------------
 func (q *DeleteQuery) Limit(n int) *DeleteQuery {
 	if !q.hasFeature(feature.DeleteOrderLimit) {
-		q.err = feature.NewNotSupportError(feature.DeleteOrderLimit)
+		q.setErr(feature.NewNotSupportError(feature.DeleteOrderLimit))
 		return q
 	}
 	q.setLimit(n)
@@ -165,7 +165,7 @@ func (q *DeleteQuery) Limit(n int) *DeleteQuery {
 // To suppress the auto-generated RETURNING clause, use `Returning("NULL")`.
 func (q *DeleteQuery) Returning(query string, args ...interface{}) *DeleteQuery {
 	if !q.hasFeature(feature.DeleteReturning) {
-		q.err = feature.NewNotSupportError(feature.DeleteOrderLimit)
+		q.setErr(feature.NewNotSupportError(feature.DeleteOrderLimit))
 		return q
 	}
 

--- a/query_insert.go
+++ b/query_insert.go
@@ -114,7 +114,7 @@ func (q *InsertQuery) ExcludeColumn(columns ...string) *InsertQuery {
 // Value overwrites model value for the column.
 func (q *InsertQuery) Value(column string, expr string, args ...interface{}) *InsertQuery {
 	if q.table == nil {
-		q.err = errNilModel
+		q.setErr(errNilModel)
 		return q
 	}
 	q.addValue(q.table, column, expr, args)

--- a/query_merge.go
+++ b/query_merge.go
@@ -30,7 +30,7 @@ func NewMergeQuery(db *DB) *MergeQuery {
 		},
 	}
 	if q.db.dialect.Name() != dialect.MSSQL && q.db.dialect.Name() != dialect.PG {
-		q.err = errors.New("bun: merge not supported for current dialect")
+		q.setErr(errors.New("bun: merge not supported for current dialect"))
 	}
 	return q
 }

--- a/query_select.go
+++ b/query_select.go
@@ -354,7 +354,7 @@ func (q *SelectQuery) JoinOnOr(cond string, args ...interface{}) *SelectQuery {
 
 func (q *SelectQuery) joinOn(cond string, args []interface{}, sep string) *SelectQuery {
 	if len(q.joins) == 0 {
-		q.err = errors.New("bun: query has no joins")
+		q.setErr(errors.New("bun: query has no joins"))
 		return q
 	}
 	j := &q.joins[len(q.joins)-1]

--- a/query_update.go
+++ b/query_update.go
@@ -123,7 +123,7 @@ func (q *UpdateQuery) SetColumn(column string, query string, args ...interface{}
 // Value overwrites model value for the column.
 func (q *UpdateQuery) Value(column string, query string, args ...interface{}) *UpdateQuery {
 	if q.table == nil {
-		q.err = errNilModel
+		q.setErr(errNilModel)
 		return q
 	}
 	q.addValue(q.table, column, query, args)
@@ -154,7 +154,7 @@ func (q *UpdateQuery) JoinOnOr(cond string, args ...interface{}) *UpdateQuery {
 
 func (q *UpdateQuery) joinOn(cond string, args []interface{}, sep string) *UpdateQuery {
 	if len(q.joins) == 0 {
-		q.err = errors.New("bun: query has no joins")
+		q.setErr(errors.New("bun: query has no joins"))
 		return q
 	}
 	j := &q.joins[len(q.joins)-1]
@@ -206,7 +206,7 @@ func (q *UpdateQuery) WhereAllWithDeleted() *UpdateQuery {
 // ------------------------------------------------------------------------------
 func (q *UpdateQuery) Order(orders ...string) *UpdateQuery {
 	if !q.hasFeature(feature.UpdateOrderLimit) {
-		q.err = feature.NewNotSupportError(feature.UpdateOrderLimit)
+		q.setErr(feature.NewNotSupportError(feature.UpdateOrderLimit))
 		return q
 	}
 	q.addOrder(orders...)
@@ -215,7 +215,7 @@ func (q *UpdateQuery) Order(orders ...string) *UpdateQuery {
 
 func (q *UpdateQuery) OrderExpr(query string, args ...interface{}) *UpdateQuery {
 	if !q.hasFeature(feature.UpdateOrderLimit) {
-		q.err = feature.NewNotSupportError(feature.UpdateOrderLimit)
+		q.setErr(feature.NewNotSupportError(feature.UpdateOrderLimit))
 		return q
 	}
 	q.addOrderExpr(query, args...)
@@ -224,7 +224,7 @@ func (q *UpdateQuery) OrderExpr(query string, args ...interface{}) *UpdateQuery 
 
 func (q *UpdateQuery) Limit(n int) *UpdateQuery {
 	if !q.hasFeature(feature.UpdateOrderLimit) {
-		q.err = feature.NewNotSupportError(feature.UpdateOrderLimit)
+		q.setErr(feature.NewNotSupportError(feature.UpdateOrderLimit))
 		return q
 	}
 	q.setLimit(n)

--- a/query_values.go
+++ b/query_values.go
@@ -52,7 +52,7 @@ func (q *ValuesQuery) Column(columns ...string) *ValuesQuery {
 // Value overwrites model value for the column.
 func (q *ValuesQuery) Value(column string, expr string, args ...interface{}) *ValuesQuery {
 	if q.table == nil {
-		q.err = errNilModel
+		q.setErr(errNilModel)
 		return q
 	}
 	q.addValue(q.table, column, expr, args)


### PR DESCRIPTION
I noticed that there were some methods setting the error on the query directly rather than using the provided setErr() method, so I standardized them all to use the setErr() method. 