### PR TITLE
fix(create_table): avoid creating unintended foreign keys

### DIFF
--- a/internal/dbtest/db_test.go
+++ b/internal/dbtest/db_test.go
@@ -1849,7 +1849,7 @@ func testNoForeignKeyForPrimaryKey(t *testing.T, db *bun.DB) {
 				bun.BaseModel `bun:"table:profiles"`
 				ID            string `bun:",pk"`
 				UserID        string
-			} `bun:"rel:belongs-to,join:id=user_id"`
+			} `bun:"rel:has-one,join:id=user_id"`
 		})(nil), dontWant: sqlschema.ForeignKey{
 			From: sqlschema.NewColumnReference("users", "id"),
 			To:   sqlschema.NewColumnReference("profiles", "user_id"),

--- a/schema/field.go
+++ b/schema/field.go
@@ -10,6 +10,7 @@ import (
 )
 
 type Field struct {
+	Table       *Table // Contains this field
 	StructField reflect.StructField
 	IsPtr       bool
 

--- a/schema/relation.go
+++ b/schema/relation.go
@@ -13,12 +13,12 @@ const (
 )
 
 type Relation struct {
+	Type  int
+	Field *Field // Has the bun tag defining this relation.
+
 	// Base and Join can be explained with this query:
 	//
 	// SELECT * FROM base_table JOIN join_table
-
-	Type      int
-	Field     *Field
 	JoinTable *Table
 	BasePKs   []*Field
 	JoinPKs   []*Field
@@ -34,10 +34,49 @@ type Relation struct {
 	M2MJoinPKs []*Field
 }
 
-// References returns true if the table to which the Relation belongs needs to declare a foreign key constraint to create the relation.
-// For other relations, the constraint is created in either the referencing table (1:N, 'has-many' relations) or a mapping table (N:N, 'm2m' relations).
+// References returns true if the table which defines this Relation
+// needs to declare a foreign key constraint, as is the case
+// for 'has-one' and 'belongs-to' relations. For other relations,
+// the constraint is created either in the referencing table (1:N, 'has-many' relations)
+// or the junction table (N:N, 'm2m' relations).
+//
+// Usage of `rel:` tag does not always imply creation of foreign keys (when WithForeignKeys() is not set)
+// and can be used exclusively for joining tables at query time. For example:
+//
+//	type User struct {
+//		ID int64			`bun:",pk"`
+//		Profile *Profile	`bun:",rel:has-one,join:id=user_id"`
+//	}
+//
+// Creating a FK users.id -> profiles.user_id would be confusing and incorrect,
+// so for such cases References() returns false. One notable exception to this rule
+// is when a Relation is defined in a junction table, in which case it is perfectly
+// fine for its primary keys to reference other tables. Consider:
+//
+//	// UsersToGroups maps users to groups they follow.
+//	type UsersToGroups struct {
+//		UserID string	`bun:"user_id,pk"`		// Needs FK to users.id
+//		GroupID string	`bun:"group_id,pk"`		// Needs FK to groups.id
+//
+//		User	*User	`bun:"rel:belongs-to,join:user_id=id"`
+//		Group	*Group	`bun:"rel:belongs-to,join:group_id=id"`
+//	}
+//
+// Here BooksToReaders has a composite primary key, composed of other primary keys.
 func (r *Relation) References() bool {
-	return r.Type == HasOneRelation || r.Type == BelongsToRelation
+	allPK := true
+	nonePK := true
+	for _, f := range r.BasePKs {
+		allPK = allPK && f.IsPK
+		nonePK = nonePK && !f.IsPK
+	}
+
+	// Erring on the side of caution, only create foreign keys
+	// if the referencing columns are part of a composite PK
+	// in the junction table of the m2m relationship.
+	effectsM2M := r.Field.Table.IsM2MTable && allPK
+
+	return (r.Type == HasOneRelation || r.Type == BelongsToRelation) && (effectsM2M || nonePK)
 }
 
 func (r *Relation) String() string {

--- a/schema/table.go
+++ b/schema/table.go
@@ -62,8 +62,9 @@ type Table struct {
 	FieldMap  map[string]*Field
 	StructMap map[string]*structField
 
-	Relations map[string]*Relation
-	Unique    map[string][]*Field
+	IsM2MTable bool // If true, this table is the "junction table" of an m2m relation.
+	Relations  map[string]*Relation
+	Unique     map[string][]*Field
 
 	SoftDeleteField       *Field
 	UpdateSoftDeleteField func(fv reflect.Value, tm time.Time) error
@@ -483,6 +484,7 @@ func (t *Table) newField(sf reflect.StructField, tag tagparser.Tag) *Field {
 	}
 
 	field := &Field{
+		Table:       t,
 		StructField: sf,
 		IsPtr:       sf.Type.Kind() == reflect.Ptr,
 
@@ -862,6 +864,7 @@ func (t *Table) m2mRelation(field *Field) *Relation {
 		JoinTable: joinTable,
 		M2MTable:  m2mTable,
 	}
+	m2mTable.markM2M()
 
 	if field.Tag.HasOption("join_on") {
 		rel.Condition = field.Tag.Options["join_on"]
@@ -905,6 +908,10 @@ func (t *Table) m2mRelation(field *Field) *Relation {
 	rel.M2MJoinPKs = rightRel.BasePKs
 
 	return rel
+}
+
+func (t *Table) markM2M() {
+	t.IsM2MTable = true
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Foreign keys should be created for has-one and belongs-to relations iff:
- None of the referencing columns is a primary keys
- The table is an m2m 'junction' table an all referencing columns are primary keys

See more details [in this comment](https://github.com/uptrace/bun/issues/1115#issuecomment-2661143967).

Closes #1115 