### PR TITLE
feat(queries): add interfaces - part 1

### DIFF
--- a/db.go
+++ b/db.go
@@ -126,7 +126,7 @@ func (db *DB) NewValues(model any) IValuesQuery {
 	return NewValuesQuery(db, model)
 }
 
-func (db *DB) NewMerge() *MergeQuery {
+func (db *DB) NewMerge() IMergeQuery {
 	return NewMergeQuery(db)
 }
 
@@ -378,7 +378,7 @@ func (c Conn) NewValues(model interface{}) IValuesQuery {
 	return NewValuesQuery(c.db, model).Conn(c)
 }
 
-func (c Conn) NewMerge() *MergeQuery {
+func (c Conn) NewMerge() IMergeQuery {
 	return NewMergeQuery(c.db).Conn(c)
 }
 
@@ -692,7 +692,7 @@ func (tx Tx) NewValues(model interface{}) IValuesQuery {
 	return NewValuesQuery(tx.db, model).Conn(tx)
 }
 
-func (tx Tx) NewMerge() *MergeQuery {
+func (tx Tx) NewMerge() IMergeQuery {
 	return NewMergeQuery(tx.db).Conn(tx)
 }
 

--- a/db.go
+++ b/db.go
@@ -122,7 +122,7 @@ func (db *DB) DBStats() DBStats {
 	}
 }
 
-func (db *DB) NewValues(model interface{}) *ValuesQuery {
+func (db *DB) NewValues(model any) IValuesQuery {
 	return NewValuesQuery(db, model)
 }
 
@@ -374,7 +374,7 @@ func (c Conn) Dialect() schema.Dialect {
 	return c.db.Dialect()
 }
 
-func (c Conn) NewValues(model interface{}) *ValuesQuery {
+func (c Conn) NewValues(model interface{}) IValuesQuery {
 	return NewValuesQuery(c.db, model).Conn(c)
 }
 
@@ -688,7 +688,7 @@ func (tx Tx) Dialect() schema.Dialect {
 	return tx.db.Dialect()
 }
 
-func (tx Tx) NewValues(model interface{}) *ValuesQuery {
+func (tx Tx) NewValues(model interface{}) IValuesQuery {
 	return NewValuesQuery(tx.db, model).Conn(tx)
 }
 

--- a/db.go
+++ b/db.go
@@ -130,7 +130,7 @@ func (db *DB) NewMerge() IMergeQuery {
 	return NewMergeQuery(db)
 }
 
-func (db *DB) NewSelect() *SelectQuery {
+func (db *DB) NewSelect() ISelectQuery {
 	return NewSelectQuery(db)
 }
 
@@ -382,7 +382,7 @@ func (c Conn) NewMerge() IMergeQuery {
 	return NewMergeQuery(c.db).Conn(c)
 }
 
-func (c Conn) NewSelect() *SelectQuery {
+func (c Conn) NewSelect() ISelectQuery {
 	return NewSelectQuery(c.db).Conn(c)
 }
 
@@ -696,7 +696,7 @@ func (tx Tx) NewMerge() IMergeQuery {
 	return NewMergeQuery(tx.db).Conn(tx)
 }
 
-func (tx Tx) NewSelect() *SelectQuery {
+func (tx Tx) NewSelect() ISelectQuery {
 	return NewSelectQuery(tx.db).Conn(tx)
 }
 

--- a/example/rel-has-many/main.go
+++ b/example/rel-has-many/main.go
@@ -46,7 +46,7 @@ func main() {
 	if err := db.NewSelect().
 		Model(user).
 		Column("user.*").
-		Relation("Profiles", func(q *bun.SelectQuery) *bun.SelectQuery {
+		Relation("Profiles", func(q bun.ISelectQuery) bun.ISelectQuery {
 			return q.Where("active IS TRUE")
 		}).
 		OrderExpr("user.id ASC").

--- a/example/rel-join-condition/main.go
+++ b/example/rel-join-condition/main.go
@@ -45,7 +45,7 @@ func main() {
 	if err := db.NewSelect().
 		Model(user).
 		Column("user.*").
-		Relation("Profiles", func(q *bun.SelectQuery) *bun.SelectQuery {
+		Relation("Profiles", func(q bun.ISelectQuery) bun.ISelectQuery {
 			return q.Where("lang = 'ru'")
 		}).
 		OrderExpr("user.id ASC").

--- a/example/rel-many-to-many/main.go
+++ b/example/rel-many-to-many/main.go
@@ -66,7 +66,7 @@ func main() {
 	order = new(Order)
 	if err := db.NewSelect().
 		Model(order).
-		Relation("Items", func(q *bun.SelectQuery) *bun.SelectQuery {
+		Relation("Items", func(q bun.ISelectQuery) bun.ISelectQuery {
 			q = q.OrderExpr("item.id DESC")
 			return q
 		}).

--- a/internal/dbtest/orm_test.go
+++ b/internal/dbtest/orm_test.go
@@ -61,14 +61,14 @@ func testBookRelations(t *testing.T, db *bun.DB) {
 		Relation("Author.Avatar").
 		Relation("Editor").
 		Relation("Editor.Avatar").
-		Relation("Genres", func(q *bun.SelectQuery) *bun.SelectQuery {
+		Relation("Genres", func(q bun.ISelectQuery) bun.ISelectQuery {
 			return q.Column("id", "name", "genre__rating")
 		}).
 		Relation("Comments").
-		Relation("Translations", func(q *bun.SelectQuery) *bun.SelectQuery {
+		Relation("Translations", func(q bun.ISelectQuery) bun.ISelectQuery {
 			return q.Order("id")
 		}).
-		Relation("Translations.Comments", func(q *bun.SelectQuery) *bun.SelectQuery {
+		Relation("Translations.Comments", func(q bun.ISelectQuery) bun.ISelectQuery {
 			return q.Order("text")
 		}).
 		OrderExpr("book.id ASC").
@@ -127,12 +127,12 @@ func testAuthorRelations(t *testing.T, db *bun.DB) {
 	err := db.NewSelect().
 		Model(&author).
 		Column("author.*").
-		Relation("Books", func(q *bun.SelectQuery) *bun.SelectQuery {
+		Relation("Books", func(q bun.ISelectQuery) bun.ISelectQuery {
 			return q.Column("book.id", "book.author_id", "book.editor_id").OrderExpr("book.id ASC")
 		}).
 		Relation("Books.Author").
 		Relation("Books.Editor").
-		Relation("Books.Translations", func(q *bun.SelectQuery) *bun.SelectQuery {
+		Relation("Books.Translations", func(q bun.ISelectQuery) bun.ISelectQuery {
 			return q.OrderExpr("tr.id ASC")
 		}).
 		OrderExpr("author.id ASC").
@@ -177,10 +177,10 @@ func testGenreRelations(t *testing.T, db *bun.DB) {
 	err := db.NewSelect().
 		Model(&genre).
 		Column("genre.*").
-		Relation("Books", func(q *bun.SelectQuery) *bun.SelectQuery {
+		Relation("Books", func(q bun.ISelectQuery) bun.ISelectQuery {
 			return q.ColumnExpr("book.id")
 		}).
-		Relation("Books.Translations", func(q *bun.SelectQuery) *bun.SelectQuery {
+		Relation("Books.Translations", func(q bun.ISelectQuery) bun.ISelectQuery {
 			return q.OrderExpr("tr.id ASC")
 		}).
 		OrderExpr("genre.id ASC").
@@ -213,7 +213,7 @@ func testTranslationRelations(t *testing.T, db *bun.DB) {
 	err := db.NewSelect().
 		Model(&translation).
 		Column("tr.*").
-		Relation("Book", func(q *bun.SelectQuery) *bun.SelectQuery {
+		Relation("Book", func(q bun.ISelectQuery) bun.ISelectQuery {
 			return q.ColumnExpr("book.id AS book__id")
 		}).
 		Relation("Book.Author").
@@ -273,7 +273,7 @@ func testRelationColumn(t *testing.T, db *bun.DB) {
 	err := db.NewSelect().
 		Model(book).
 		ExcludeColumn("created_at").
-		Relation("Author", func(q *bun.SelectQuery) *bun.SelectQuery {
+		Relation("Author", func(q bun.ISelectQuery) bun.ISelectQuery {
 			return q.Column("name")
 		}).
 		OrderExpr("book.id").
@@ -296,7 +296,7 @@ func testRelationExcludeAll(t *testing.T, db *bun.DB) {
 	err := db.NewSelect().
 		Model(book).
 		ExcludeColumn("created_at").
-		Relation("Author", func(q *bun.SelectQuery) *bun.SelectQuery {
+		Relation("Author", func(q bun.ISelectQuery) bun.ISelectQuery {
 			return q.ExcludeColumn("*")
 		}).
 		Relation("Author.Avatar").
@@ -327,7 +327,7 @@ func testRelationExcludeAll(t *testing.T, db *bun.DB) {
 	err = db.NewSelect().
 		Model(book).
 		ExcludeColumn("*").
-		Relation("Author", func(q *bun.SelectQuery) *bun.SelectQuery {
+		Relation("Author", func(q bun.ISelectQuery) bun.ISelectQuery {
 			return q.ExcludeColumn("*")
 		}).
 		Relation("Author.Avatar").
@@ -427,7 +427,7 @@ func testM2MRelationExcludeColumn(t *testing.T, db *bun.DB) {
 	err = db.NewSelect().
 		Model(order).
 		Where("id = ?", 1).
-		Relation("Items", func(sq *bun.SelectQuery) *bun.SelectQuery {
+		Relation("Items", func(sq bun.ISelectQuery) bun.ISelectQuery {
 			return sq.ExcludeColumn("updated_at")
 		}).
 		Scan(ctx)
@@ -580,7 +580,7 @@ func testHasOneRelationWithOpts(t *testing.T, db *bun.DB) {
 		NewSelect().
 		Model(&outUsers2).
 		RelationWithOpts("Profile", bun.RelationOpts{
-			Apply: func(q *bun.SelectQuery) *bun.SelectQuery {
+			Apply: func(q bun.ISelectQuery) bun.ISelectQuery {
 				return q.Where("profile.lang = ?", "ru")
 			},
 		}).
@@ -654,7 +654,7 @@ func testHasManyRelationWithOpts(t *testing.T, db *bun.DB) {
 		NewSelect().
 		Model(&outUsers2).
 		RelationWithOpts("Profiles", bun.RelationOpts{
-			Apply: func(q *bun.SelectQuery) *bun.SelectQuery {
+			Apply: func(q bun.ISelectQuery) bun.ISelectQuery {
 				return q.Where("profile.lang = ?", "ru")
 			},
 		}).

--- a/internal/dbtest/query_test.go
+++ b/internal/dbtest/query_test.go
@@ -360,11 +360,11 @@ func TestQuery(t *testing.T) {
 				return db.NewSelect().Model(new(Model)).
 					Where("1").
 					WhereOr("2").
-					WhereGroup(" OR ", func(q *bun.SelectQuery) *bun.SelectQuery {
+					WhereGroup(" OR ", func(q bun.ISelectQuery) bun.ISelectQuery {
 						return q.
 							WhereOr("3").
 							WhereOr("4").
-							WhereGroup(" OR NOT ", func(q *bun.SelectQuery) *bun.SelectQuery {
+							WhereGroup(" OR NOT ", func(q bun.ISelectQuery) bun.ISelectQuery {
 								return q.
 									WhereOr("5").
 									WhereOr("6")
@@ -451,7 +451,7 @@ func TestQuery(t *testing.T) {
 			query: func(db *bun.DB) schema.QueryAppender {
 				return db.NewSelect().
 					Model(new(Story)).
-					Relation("User", func(q *bun.SelectQuery) *bun.SelectQuery {
+					Relation("User", func(q bun.ISelectQuery) bun.ISelectQuery {
 						q = q.ExcludeColumn("*")
 						return q
 					})
@@ -462,7 +462,7 @@ func TestQuery(t *testing.T) {
 			query: func(db *bun.DB) schema.QueryAppender {
 				return db.NewSelect().
 					Model(new(Story)).
-					Relation("User", func(q *bun.SelectQuery) *bun.SelectQuery {
+					Relation("User", func(q bun.ISelectQuery) bun.ISelectQuery {
 						q = q.ExcludeColumn("id")
 						return q
 					})
@@ -689,10 +689,10 @@ func TestQuery(t *testing.T) {
 			id: 72,
 			query: func(db *bun.DB) schema.QueryAppender {
 				return db.NewSelect().
-					WhereGroup("", func(q *bun.SelectQuery) *bun.SelectQuery {
+					WhereGroup("", func(q bun.ISelectQuery) bun.ISelectQuery {
 						return q.Where("a = 1").Where("b = 1")
 					}).
-					WhereGroup(" OR ", func(q *bun.SelectQuery) *bun.SelectQuery {
+					WhereGroup(" OR ", func(q bun.ISelectQuery) bun.ISelectQuery {
 						return q.Where("a = 2").Where("b = 2")
 					})
 			},
@@ -745,7 +745,7 @@ func TestQuery(t *testing.T) {
 		{
 			id: 78,
 			query: func(db *bun.DB) schema.QueryAppender {
-				return db.NewSelect().WhereGroup(" AND ", func(q *bun.SelectQuery) *bun.SelectQuery {
+				return db.NewSelect().WhereGroup(" AND ", func(q bun.ISelectQuery) bun.ISelectQuery {
 					return q.WhereOr("one").WhereOr("two")
 				})
 			},

--- a/internal/dbtest/test.sh
+++ b/internal/dbtest/test.sh
@@ -1,10 +1,21 @@
 #!/bin/sh -eux
+
+if command -v docker compose >/dev/null 2>/dev/null; then
+  DOCKER_CMD="docker compose"
+elif command -v docker-compose >/dev/null 2>/dev/null; then
+  DOCKER_CMD="docker-compose"
+else
+  echo "Error: Neither 'docker compose' nor 'docker-compose' is available."
+  exit 1
+fi
+
 cd mssql-docker
 docker build -t mssql-local .
 cd ..
-trap 'docker-compose down -v' EXIT
-docker-compose down -v
-docker-compose up -d
+# shellcheck disable=SC2064
+trap "${DOCKER_CMD} down -v" EXIT
+${DOCKER_CMD} down -v
+${DOCKER_CMD} up -d
 sleep 30
 CGO_ENABLED=0 TZ= go test "$@"
 CGO_ENABLED=1 TZ= go test -tags cgosqlite "$@"

--- a/query_base.go
+++ b/query_base.go
@@ -54,7 +54,7 @@ type IDB interface {
 	NewInsert() *InsertQuery
 	NewUpdate() *UpdateQuery
 	NewDelete() *DeleteQuery
-	NewMerge() *MergeQuery
+	NewMerge() IMergeQuery
 	NewRaw(query string, args ...interface{}) *RawQuery
 	NewCreateTable() *CreateTableQuery
 	NewDropTable() *DropTableQuery

--- a/query_base.go
+++ b/query_base.go
@@ -50,7 +50,7 @@ type IDB interface {
 	Dialect() schema.Dialect
 
 	NewValues(model any) IValuesQuery
-	NewSelect() *SelectQuery
+	NewSelect() ISelectQuery
 	NewInsert() *InsertQuery
 	NewUpdate() *UpdateQuery
 	NewDelete() *DeleteQuery
@@ -107,7 +107,7 @@ type IBaseQuery interface {
 	NewDropTable() *DropTableQuery
 	NewInsert() *InsertQuery
 	NewRaw(query string, args ...interface{}) *RawQuery
-	NewSelect() *SelectQuery
+	NewSelect() ISelectQuery
 	NewTruncateTable() *TruncateTableQuery
 	NewUpdate() *UpdateQuery
 	NewValues(model interface{}) *ValuesQuery
@@ -679,7 +679,7 @@ func (q *baseQuery) NewValues(model interface{}) *ValuesQuery {
 	return NewValuesQuery(q.db, model).Conn(q.conn)
 }
 
-func (q *baseQuery) NewSelect() *SelectQuery {
+func (q *baseQuery) NewSelect() ISelectQuery {
 	return NewSelectQuery(q.db).Conn(q.conn)
 }
 

--- a/query_base.go
+++ b/query_base.go
@@ -92,6 +92,27 @@ var (
 	_ QueryBuilder = (*deleteQueryBuilder)(nil)
 )
 
+type IBaseQuery interface {
+	AppendNamedArg(fmter schema.Formatter, b []byte, name string) ([]byte, bool)
+	DB() *DB
+	Dialect() schema.Dialect
+	GetModel() Model
+	GetTableName() string
+	NewAddColumn() *AddColumnQuery
+	NewCreateIndex() *CreateIndexQuery
+	NewCreateTable() *CreateTableQuery
+	NewDelete() *DeleteQuery
+	NewDropColumn() *DropColumnQuery
+	NewDropIndex() *DropIndexQuery
+	NewDropTable() *DropTableQuery
+	NewInsert() *InsertQuery
+	NewRaw(query string, args ...interface{}) *RawQuery
+	NewSelect() *SelectQuery
+	NewTruncateTable() *TruncateTableQuery
+	NewUpdate() *UpdateQuery
+	NewValues(model interface{}) *ValuesQuery
+}
+
 type baseQuery struct {
 	db   *DB
 	conn IConn

--- a/query_base.go
+++ b/query_base.go
@@ -49,7 +49,7 @@ type IDB interface {
 	IConn
 	Dialect() schema.Dialect
 
-	NewValues(model interface{}) *ValuesQuery
+	NewValues(model any) IValuesQuery
 	NewSelect() *SelectQuery
 	NewInsert() *InsertQuery
 	NewUpdate() *UpdateQuery

--- a/query_update.go
+++ b/query_update.go
@@ -469,7 +469,7 @@ func (q *UpdateQuery) Bulk() *UpdateQuery {
 		return q
 	}
 
-	values := q.db.NewValues(model)
+	values := NewValuesQuery(q.db, model)
 	values.customValueQuery = q.customValueQuery
 
 	return q.With("_data", values).

--- a/query_values.go
+++ b/query_values.go
@@ -9,6 +9,20 @@ import (
 	"github.com/uptrace/bun/schema"
 )
 
+type IValuesQuery interface {
+	IBaseQuery
+
+	AppendColumns(fmter schema.Formatter, b []byte) (_ []byte, err error)
+	AppendQuery(fmter schema.Formatter, b []byte) (_ []byte, err error)
+	Column(columns ...string) *ValuesQuery
+	Comment(comment string) *ValuesQuery
+	Conn(db IConn) *ValuesQuery
+	Err(err error) *ValuesQuery
+	Operation() string
+	Value(column string, expr string, args ...any) *ValuesQuery
+	WithOrder() *ValuesQuery
+}
+
 type ValuesQuery struct {
 	baseQuery
 	customValueQuery
@@ -22,13 +36,14 @@ var (
 	_ schema.NamedArgAppender = (*ValuesQuery)(nil)
 )
 
-func NewValuesQuery(db *DB, model interface{}) *ValuesQuery {
+func NewValuesQuery(db *DB, model any) *ValuesQuery {
 	q := &ValuesQuery{
 		baseQuery: baseQuery{
 			db: db,
 		},
 	}
 	q.setModel(model)
+
 	return q
 }
 
@@ -50,7 +65,7 @@ func (q *ValuesQuery) Column(columns ...string) *ValuesQuery {
 }
 
 // Value overwrites model value for the column.
-func (q *ValuesQuery) Value(column string, expr string, args ...interface{}) *ValuesQuery {
+func (q *ValuesQuery) Value(column string, expr string, args ...any) *ValuesQuery {
 	if q.table == nil {
 		q.setErr(errNilModel)
 		return q


### PR DESCRIPTION
Part of #1144

Every query structures inside `bun` uses the structure itself to function properly. While this behavior is good, it is not flexing for testing and/or re-implementing certain features.

Adding interfaces add this flexibility.

This PR is part of a group to implement interfaces where necessary to increase the DX.