### PR TITLE
Add option for unicode to mssql dialect

### DIFF
--- a/dialect/mssqldialect/dialect.go
+++ b/dialect/mssqldialect/dialect.go
@@ -37,6 +37,8 @@ type Dialect struct {
 
 	tables   *schema.Tables
 	features feature.Feature
+
+	unicode bool
 }
 
 func New(opts ...DialectOption) *Dialect {
@@ -50,6 +52,8 @@ func New(opts ...DialectOption) *Dialect {
 		feature.UpdateFromTable |
 		feature.MSSavepoint
 
+	d.unicode = true
+
 	for _, opt := range opts {
 		opt(d)
 	}
@@ -61,6 +65,12 @@ type DialectOption func(d *Dialect)
 func WithoutFeature(other feature.Feature) DialectOption {
 	return func(d *Dialect) {
 		d.features = d.features.Remove(other)
+	}
+}
+
+func WithUnicode(on bool) DialectOption {
+	return func(d *Dialect) {
+		d.unicode = on
 	}
 }
 
@@ -140,8 +150,11 @@ func (*Dialect) AppendBool(b []byte, v bool) []byte {
 }
 
 func (d *Dialect) AppendString(b []byte, s string) []byte {
-	// 'N' prefix means the string uses Unicode encoding.
-	b = append(b, 'N')
+	if d.unicode {
+		// 'N' prefix means the string uses Unicode encoding.
+		b = append(b, 'N')
+	}
+
 	return d.BaseDialect.AppendString(b, s)
 }
 


### PR DESCRIPTION
Add an option to support non unicode collated mssqlserver dialect.

Fixes [#824](https://github.com/uptrace/bun/issues/824), and based on [PR-828](https://github.com/uptrace/bun/pull/828), but with a global option instead of a local option