### PR TITLE
fix(gh-1160): add WithExcludeForeignKeys option

### DIFF
--- a/dialect/pgdialect/inspector.go
+++ b/dialect/pgdialect/inspector.go
@@ -113,10 +113,14 @@ func (in *Inspector) Inspect(ctx context.Context) (sqlschema.Database, error) {
 	}
 
 	for _, fk := range fks {
-		dbSchema.ForeignKeys[sqlschema.ForeignKey{
+		dbFK := sqlschema.ForeignKey{
 			From: sqlschema.NewColumnReference(fk.SourceTable, fk.SourceColumns...),
 			To:   sqlschema.NewColumnReference(fk.TargetTable, fk.TargetColumns...),
-		}] = fk.ConstraintName
+		}
+		if _, exclude := in.ExcludeForeignKeys[dbFK]; exclude {
+			continue
+		}
+		dbSchema.ForeignKeys[dbFK] = fk.ConstraintName
 	}
 	return dbSchema, nil
 }

--- a/migrate/auto.go
+++ b/migrate/auto.go
@@ -24,7 +24,7 @@ func WithModel(models ...interface{}) AutoMigratorOption {
 	}
 }
 
-// WithExcludeTable tells the AutoMigrator to ignore a table in the database.
+// WithExcludeTable tells AutoMigrator to ignore a table in the database.
 // This prevents AutoMigrator from dropping tables which may exist in the schema
 // but which are not used by the application.
 //
@@ -35,6 +35,9 @@ func WithExcludeTable(tables ...string) AutoMigratorOption {
 	}
 }
 
+// WithExcludeForeignKeys tells AutoMigrator to exclude a foreign key constaint
+// from the migration scope. This prevents AutoMigrator from dropping foreign keys
+// that are defined manually via CreateTableQuery.ForeignKey().
 func WithExcludeForeignKeys(fks ...sqlschema.ForeignKey) AutoMigratorOption {
 	return func(m *AutoMigrator) {
 		m.excludeForeignKeys = append(m.excludeForeignKeys, fks...)

--- a/migrate/sqlschema/inspector.go
+++ b/migrate/sqlschema/inspector.go
@@ -30,6 +30,12 @@ type InspectorDialect interface {
 // InspectorConfig controls the scope of migration by limiting the objects Inspector should return.
 // Inspectors SHOULD use the configuration directly instead of copying it, or MAY choose to embed it,
 // to make sure options are always applied correctly.
+//
+// ExcludeTables and ExcludeForeignKeys are intended for database inspectors,
+// to compensate for the fact that model structs may not wholly reflect the
+// state of the database schema.
+// Database inspectors MUST respect these exclusions to prevent relations
+// from being dropped unintentionally.
 type InspectorConfig struct {
 	// SchemaName limits inspection to tables in a particular schema.
 	SchemaName string
@@ -52,13 +58,17 @@ func WithSchemaName(schemaName string) InspectorOption {
 	}
 }
 
-// WithExcludeTables works in append-only mode, i.e. tables cannot be re-included.
+// WithExcludeTables forces inspector to exclude tables
+// from the reported schema state.
+// It works in append-only mode, i.e. tables cannot be re-included.
 func WithExcludeTables(tables ...string) InspectorOption {
 	return func(cfg *InspectorConfig) {
 		cfg.ExcludeTables = append(cfg.ExcludeTables, tables...)
 	}
 }
 
+// WithExcludeForeignKeys forces inspector to exclude foreign keys
+// from the reported schema state.
 func WithExcludeForeignKeys(fks ...ForeignKey) InspectorOption {
 	return func(cfg *InspectorConfig) {
 		for _, fk := range fks {

--- a/migrate/sqlschema/inspector.go
+++ b/migrate/sqlschema/inspector.go
@@ -36,6 +36,9 @@ type InspectorConfig struct {
 
 	// ExcludeTables from inspection.
 	ExcludeTables []string
+
+	// ExcludeForeignKeys from inspection.
+	ExcludeForeignKeys map[ForeignKey]string
 }
 
 // Inspector reads schema state.
@@ -53,6 +56,14 @@ func WithSchemaName(schemaName string) InspectorOption {
 func WithExcludeTables(tables ...string) InspectorOption {
 	return func(cfg *InspectorConfig) {
 		cfg.ExcludeTables = append(cfg.ExcludeTables, tables...)
+	}
+}
+
+func WithExcludeForeignKeys(fks ...ForeignKey) InspectorOption {
+	return func(cfg *InspectorConfig) {
+		for _, fk := range fks {
+			cfg.ExcludeForeignKeys[fk] = ""
+		}
 	}
 }
 
@@ -78,6 +89,9 @@ func NewBunModelInspector(tables *schema.Tables, options ...InspectorOption) *Bu
 type InspectorOption func(*InspectorConfig)
 
 func ApplyInspectorOptions(cfg *InspectorConfig, options ...InspectorOption) {
+	if cfg.ExcludeForeignKeys == nil {
+		cfg.ExcludeForeignKeys = make(map[ForeignKey]string)
+	}
 	for _, opt := range options {
 		opt(cfg)
 	}
@@ -212,7 +226,7 @@ func parseLen(typ string) (string, int, error) {
 }
 
 // exprOrLiteral converts string to lowercase, if it does not contain a string literal 'lit'
-// and trims the surrounding '' otherwise.
+// and trims the surrounding ” otherwise.
 // Use it to ensure that user-defined default values in the models are always comparable
 // to those returned by the database inspector, regardless of the case convention in individual drivers.
 func exprOrLiteral(s string) string {

--- a/migrate/sqlschema/inspector.go
+++ b/migrate/sqlschema/inspector.go
@@ -236,7 +236,7 @@ func parseLen(typ string) (string, int, error) {
 }
 
 // exprOrLiteral converts string to lowercase, if it does not contain a string literal 'lit'
-// and trims the surrounding ” otherwise.
+// and trims the surrounding '' otherwise.
 // Use it to ensure that user-defined default values in the models are always comparable
 // to those returned by the database inspector, regardless of the case convention in individual drivers.
 func exprOrLiteral(s string) string {


### PR DESCRIPTION
Closes #1160 

Inspectors cannot detect foreign keys created via CreateTableQuery.ForeignKey() using reflection. This leads AutoMigrator to delete all such FKs.

The added option allows excluding manually created foreign keys from the inspection/migration scope.