### PR TITLE
chore: add test case for acronyms

### DIFF
--- a/internal/dbtest/query_test.go
+++ b/internal/dbtest/query_test.go
@@ -1680,7 +1680,6 @@ func TestQuery(t *testing.T) {
 					}).
 					Comment("test").
 					Returning("$action")
-
 			},
 		},
 		{
@@ -1736,6 +1735,19 @@ func TestQuery(t *testing.T) {
 			query: func(db *bun.DB) schema.QueryAppender {
 				return db.NewValues(&[]Model{{1, "hello"}}).
 					Comment("test")
+			},
+		},
+		{
+			id: 187,
+			query: func(db *bun.DB) schema.QueryAppender {
+				type AcronymPDF struct {
+					UserID         string `bun:",pk"`
+					InnerHTML      string
+					HTTPProxy      string
+					MaxCPU         int
+					SSLCertificate []byte
+				}
+				return db.NewCreateTable().Model(new(AcronymPDF))
 			},
 		},
 	}

--- a/internal/dbtest/testdata/snapshots/TestQuery-mariadb-187
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mariadb-187
@@ -1,0 +1,1 @@
+CREATE TABLE `acronym_pdfs` (`user_id` VARCHAR(255) NOT NULL, `inner_html` VARCHAR(255), `http_proxy` VARCHAR(255), `max_cpu` BIGINT, `ssl_certificate` BLOB, PRIMARY KEY (`user_id`))

--- a/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-187
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-187
@@ -1,0 +1,1 @@
+CREATE TABLE "acronym_pdfs" ("user_id" VARCHAR(255) NOT NULL, "inner_html" VARCHAR(255), "http_proxy" VARCHAR(255), "max_cpu" BIGINT, "ssl_certificate" VARBINARY(MAX), PRIMARY KEY ("user_id"))

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql5-187
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql5-187
@@ -1,0 +1,1 @@
+CREATE TABLE `acronym_pdfs` (`user_id` VARCHAR(255) NOT NULL, `inner_html` VARCHAR(255), `http_proxy` VARCHAR(255), `max_cpu` BIGINT, `ssl_certificate` BLOB, PRIMARY KEY (`user_id`))

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql8-187
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql8-187
@@ -1,0 +1,1 @@
+CREATE TABLE `acronym_pdfs` (`user_id` VARCHAR(255) NOT NULL, `inner_html` VARCHAR(255), `http_proxy` VARCHAR(255), `max_cpu` BIGINT, `ssl_certificate` BLOB, PRIMARY KEY (`user_id`))

--- a/internal/dbtest/testdata/snapshots/TestQuery-pg-187
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pg-187
@@ -1,0 +1,1 @@
+CREATE TABLE "acronym_pdfs" ("user_id" VARCHAR NOT NULL, "inner_html" VARCHAR, "http_proxy" VARCHAR, "max_cpu" BIGINT, "ssl_certificate" BYTEA, PRIMARY KEY ("user_id"))

--- a/internal/dbtest/testdata/snapshots/TestQuery-pgx-187
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pgx-187
@@ -1,0 +1,1 @@
+CREATE TABLE "acronym_pdfs" ("user_id" VARCHAR NOT NULL, "inner_html" VARCHAR, "http_proxy" VARCHAR, "max_cpu" BIGINT, "ssl_certificate" BYTEA, PRIMARY KEY ("user_id"))

--- a/internal/dbtest/testdata/snapshots/TestQuery-sqlite-187
+++ b/internal/dbtest/testdata/snapshots/TestQuery-sqlite-187
@@ -1,0 +1,1 @@
+CREATE TABLE "acronym_pdfs" ("user_id" VARCHAR NOT NULL, "inner_html" VARCHAR, "http_proxy" VARCHAR, "max_cpu" INTEGER, "ssl_certificate" BLOB, PRIMARY KEY ("user_id"))


### PR DESCRIPTION
Related #1154 

User's claims that CamelCase conversion is broken and that

> UserID is getting converted to user_i_d

This PR adds a test case to TestQuery suit to verify that, when running a CreateNewTable query, table/column names containing acronyms are converted to snake_case without breaking the acronyms apart, i.e. UserID -> user_id.

