### PR TITLE
refactor(automigrate): Limit ordered.Map usage to migrator internals

### DIFF
--- a/dialect/pgdialect/inspector.go
+++ b/dialect/pgdialect/inspector.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/uptrace/bun"
-	"github.com/uptrace/bun/internal/ordered"
 	"github.com/uptrace/bun/migrate/sqlschema"
 )
 
@@ -60,7 +59,7 @@ func (in *Inspector) Inspect(ctx context.Context) (sqlschema.Database, error) {
 			return dbSchema, err
 		}
 
-		colDefs := ordered.NewMap[string, sqlschema.Column]()
+		var colDefs []sqlschema.Column
 		uniqueGroups := make(map[string][]string)
 
 		for _, c := range columns {
@@ -71,7 +70,7 @@ func (in *Inspector) Inspect(ctx context.Context) (sqlschema.Database, error) {
 				def = strings.ToLower(def)
 			}
 
-			colDefs.Store(c.Name, &Column{
+			colDefs = append(colDefs, &Column{
 				Name:            c.Name,
 				SQLType:         c.DataType,
 				VarcharLen:      c.VarcharLen,

--- a/dialect/pgdialect/inspector.go
+++ b/dialect/pgdialect/inspector.go
@@ -34,7 +34,6 @@ func newInspector(db *bun.DB, options ...sqlschema.InspectorOption) *Inspector {
 
 func (in *Inspector) Inspect(ctx context.Context) (sqlschema.Database, error) {
 	dbSchema := Schema{
-		Tables:      ordered.NewMap[string, sqlschema.Table](),
 		ForeignKeys: make(map[sqlschema.ForeignKey]string),
 	}
 
@@ -103,7 +102,7 @@ func (in *Inspector) Inspect(ctx context.Context) (sqlschema.Database, error) {
 			}
 		}
 
-		dbSchema.Tables.Store(table.Name, &Table{
+		dbSchema.Tables = append(dbSchema.Tables, &Table{
 			Schema:            table.Schema,
 			Name:              table.Name,
 			Columns:           colDefs,

--- a/internal/dbtest/inspect_test.go
+++ b/internal/dbtest/inspect_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/dialect/sqltype"
-	"github.com/uptrace/bun/internal/ordered"
 	"github.com/uptrace/bun/migrate/sqlschema"
 	"github.com/uptrace/bun/schema"
 )
@@ -91,81 +90,65 @@ func TestDatabaseInspector_Inspect(t *testing.T) {
 					&sqlschema.BaseTable{
 						Schema: defaultSchema,
 						Name:   "articles",
-						Columns: ordered.NewMap[string, sqlschema.Column](
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "isbn",
-								Value: &sqlschema.BaseColumn{
-									SQLType:         "bigint",
-									IsNullable:      false,
-									IsAutoIncrement: false,
-									IsIdentity:      true,
-									DefaultValue:    "",
-								},
+						Columns: []sqlschema.Column{
+							&sqlschema.BaseColumn{
+								Name:            "isbn",
+								SQLType:         "bigint",
+								IsNullable:      false,
+								IsAutoIncrement: false,
+								IsIdentity:      true,
+								DefaultValue:    "",
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "editor",
-								Value: &sqlschema.BaseColumn{
-									SQLType:         sqltype.VarChar,
-									IsNullable:      false,
-									IsAutoIncrement: false,
-									IsIdentity:      false,
-									DefaultValue:    "john doe",
-								},
+							&sqlschema.BaseColumn{
+								Name:            "editor",
+								SQLType:         sqltype.VarChar,
+								IsNullable:      false,
+								IsAutoIncrement: false,
+								IsIdentity:      false,
+								DefaultValue:    "john doe",
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "title",
-								Value: &sqlschema.BaseColumn{
-									SQLType:         sqltype.VarChar,
-									IsNullable:      false,
-									IsAutoIncrement: false,
-									IsIdentity:      false,
-									DefaultValue:    "",
-								},
+							&sqlschema.BaseColumn{
+								Name:            "title",
+								SQLType:         sqltype.VarChar,
+								IsNullable:      false,
+								IsAutoIncrement: false,
+								IsIdentity:      false,
+								DefaultValue:    "",
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "locale",
-								Value: &sqlschema.BaseColumn{
-									SQLType:         sqltype.VarChar,
-									VarcharLen:      5,
-									IsNullable:      true,
-									IsAutoIncrement: false,
-									IsIdentity:      false,
-									DefaultValue:    "en-GB",
-								},
+							&sqlschema.BaseColumn{
+								Name:            "locale",
+								SQLType:         sqltype.VarChar,
+								VarcharLen:      5,
+								IsNullable:      true,
+								IsAutoIncrement: false,
+								IsIdentity:      false,
+								DefaultValue:    "en-GB",
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "page_count",
-								Value: &sqlschema.BaseColumn{
-									SQLType:         "smallint",
-									IsNullable:      false,
-									IsAutoIncrement: false,
-									IsIdentity:      false,
-									DefaultValue:    "1",
-								},
+							&sqlschema.BaseColumn{
+								Name:            "page_count",
+								SQLType:         "smallint",
+								IsNullable:      false,
+								IsAutoIncrement: false,
+								IsIdentity:      false,
+								DefaultValue:    "1",
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "book_count",
-								Value: &sqlschema.BaseColumn{
-									SQLType:         "integer",
-									IsNullable:      false,
-									IsAutoIncrement: true,
-									IsIdentity:      false,
-									DefaultValue:    "",
-								},
+							&sqlschema.BaseColumn{
+								Name:            "book_count",
+								SQLType:         "integer",
+								IsNullable:      false,
+								IsAutoIncrement: true,
+								IsIdentity:      false,
+								DefaultValue:    "",
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "publisher_id",
-								Value: &sqlschema.BaseColumn{
-									SQLType: sqltype.VarChar,
-								},
+							&sqlschema.BaseColumn{
+								Name:    "publisher_id",
+								SQLType: sqltype.VarChar,
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "author_id",
-								Value: &sqlschema.BaseColumn{
-									SQLType: "bigint",
-								},
+							&sqlschema.BaseColumn{
+								Name:    "author_id",
+								SQLType: "bigint",
 							},
-						),
+						},
 						PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("isbn")},
 						UniqueConstraints: []sqlschema.Unique{
 							{Columns: sqlschema.NewColumns("editor", "title")},
@@ -174,33 +157,25 @@ func TestDatabaseInspector_Inspect(t *testing.T) {
 					&sqlschema.BaseTable{
 						Schema: defaultSchema,
 						Name:   "authors",
-						Columns: ordered.NewMap[string, sqlschema.Column](
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "author_id",
-								Value: &sqlschema.BaseColumn{
-									SQLType:    "bigint",
-									IsIdentity: true,
-								},
+						Columns: []sqlschema.Column{
+							&sqlschema.BaseColumn{
+								Name:       "author_id",
+								SQLType:    "bigint",
+								IsIdentity: true,
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "first_name",
-								Value: &sqlschema.BaseColumn{
-									SQLType: sqltype.VarChar,
-								},
+							&sqlschema.BaseColumn{
+								Name:    "first_name",
+								SQLType: sqltype.VarChar,
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "last_name",
-								Value: &sqlschema.BaseColumn{
-									SQLType: sqltype.VarChar,
-								},
+							&sqlschema.BaseColumn{
+								Name:    "last_name",
+								SQLType: sqltype.VarChar,
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "email",
-								Value: &sqlschema.BaseColumn{
-									SQLType: sqltype.VarChar,
-								},
+							&sqlschema.BaseColumn{
+								Name:    "email",
+								SQLType: sqltype.VarChar,
 							},
-						),
+						},
 						PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("author_id")},
 						UniqueConstraints: []sqlschema.Unique{
 							{Columns: sqlschema.NewColumns("first_name", "last_name")},
@@ -210,48 +185,38 @@ func TestDatabaseInspector_Inspect(t *testing.T) {
 					&sqlschema.BaseTable{
 						Schema: defaultSchema,
 						Name:   "publisher_to_journalists",
-						Columns: ordered.NewMap[string, sqlschema.Column](
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "publisher_id",
-								Value: &sqlschema.BaseColumn{
-									SQLType: sqltype.VarChar,
-								},
+						Columns: []sqlschema.Column{
+							&sqlschema.BaseColumn{
+								Name:    "publisher_id",
+								SQLType: sqltype.VarChar,
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "author_id",
-								Value: &sqlschema.BaseColumn{
-									SQLType: "bigint",
-								},
+							&sqlschema.BaseColumn{
+								Name:    "author_id",
+								SQLType: "bigint",
 							},
-						),
+						},
 						PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("publisher_id", "author_id")},
 					},
 					&sqlschema.BaseTable{
 						Schema: defaultSchema,
 						Name:   "publishers",
-						Columns: ordered.NewMap[string, sqlschema.Column](
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "publisher_id",
-								Value: &sqlschema.BaseColumn{
-									SQLType:      sqltype.VarChar,
-									DefaultValue: "gen_random_uuid()",
-								},
+						Columns: []sqlschema.Column{
+							&sqlschema.BaseColumn{
+								Name:         "publisher_id",
+								SQLType:      sqltype.VarChar,
+								DefaultValue: "gen_random_uuid()",
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "publisher_name",
-								Value: &sqlschema.BaseColumn{
-									SQLType: sqltype.VarChar,
-								},
+							&sqlschema.BaseColumn{
+								Name:    "publisher_name",
+								SQLType: sqltype.VarChar,
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "created_at",
-								Value: &sqlschema.BaseColumn{
-									SQLType:      "timestamp",
-									DefaultValue: "current_timestamp",
-									IsNullable:   true,
-								},
+							&sqlschema.BaseColumn{
+								Name:         "created_at",
+								SQLType:      "timestamp",
+								DefaultValue: "current_timestamp",
+								IsNullable:   true,
 							},
-						),
+						},
 						PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("publisher_id")},
 						UniqueConstraints: []sqlschema.Unique{
 							{Columns: sqlschema.NewColumns("publisher_id", "publisher_name")},
@@ -284,28 +249,22 @@ func TestDatabaseInspector_Inspect(t *testing.T) {
 					&sqlschema.BaseTable{
 						Schema: "admin",
 						Name:   "offices",
-						Columns: ordered.NewMap[string, sqlschema.Column](
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "office_name",
-								Value: &sqlschema.BaseColumn{
-									SQLType: sqltype.VarChar,
-								},
+						Columns: []sqlschema.Column{
+							&sqlschema.BaseColumn{
+								Name:    "office_name",
+								SQLType: sqltype.VarChar,
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "publisher_id",
-								Value: &sqlschema.BaseColumn{
-									SQLType:    sqltype.VarChar,
-									IsNullable: true,
-								},
+							&sqlschema.BaseColumn{
+								Name:       "publisher_id",
+								SQLType:    sqltype.VarChar,
+								IsNullable: true,
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "publisher_name",
-								Value: &sqlschema.BaseColumn{
-									SQLType:    sqltype.VarChar,
-									IsNullable: true,
-								},
+							&sqlschema.BaseColumn{
+								Name:       "publisher_name",
+								SQLType:    sqltype.VarChar,
+								IsNullable: true,
 							},
-						),
+						},
 						PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("office_name")},
 					},
 				},
@@ -391,9 +350,9 @@ func cmpTables(
 	// They might still appear in a different order, here's a helper to find matching tables.
 	findGot := func(t testing.TB, name string) sqlschema.Table {
 		t.Helper()
-		for _, t := range got {
-			if t.GetName() == name {
-				return t
+		for _, table := range got {
+			if table.GetName() == name {
+				return table
 			}
 		}
 		// This should never happen, as we've verified that table names match.
@@ -413,21 +372,35 @@ func cmpColumns(
 	tb testing.TB,
 	d sqlschema.InspectorDialect,
 	tableName string,
-	want, got *ordered.Map[string, sqlschema.Column],
+	want, got []sqlschema.Column,
 ) {
 	tb.Helper()
 	var errs []string
 
 	var missing []string
-	for _, cPair := range want.Pairs() {
-		colName := cPair.Key
+	findGot := func(name string) sqlschema.Column {
+		for _, col := range got {
+			if col.GetName() == name {
+				return col
+			}
+		}
+		// This should never happen, as we've verified that table names match.
+		missing = append(missing, name)
+		return nil
+	}
+
+	wantColumnNames := make(map[string]struct{}, len(want))
+	for _, wantColumn := range want {
+		colName := wantColumn.GetName()
+		wantColumnNames[colName] = struct{}{}
+
 		errorf := func(format string, args ...interface{}) {
 			errs = append(errs, fmt.Sprintf("[%s.%s] "+format, append([]interface{}{tableName, colName}, args...)...))
 		}
-		wantCol := cPair.Value.(*sqlschema.BaseColumn)
-		gotCol, ok := got.Value(colName).(*sqlschema.BaseColumn)
-		if !ok {
-			missing = append(missing, colName)
+
+		wantCol := wantColumn.(*sqlschema.BaseColumn)
+		gotCol := findGot(colName).(*sqlschema.BaseColumn)
+		if gotCol == nil {
 			continue
 		}
 
@@ -457,9 +430,9 @@ func cmpColumns(
 	}
 
 	var extra []string
-	for _, colName := range got.Keys() {
-		if _, ok := want.Load(colName); !ok {
-			extra = append(extra, colName)
+	for _, c := range got {
+		if _, ok := wantColumnNames[c.GetName()]; !ok {
+			extra = append(extra, c.GetName())
 		}
 	}
 
@@ -523,22 +496,18 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 			tables.Register((*Model)(nil))
 			inspector := sqlschema.NewBunModelInspector(tables, sqlschema.WithSchemaName(dialect.DefaultSchema()))
 
-			want := ordered.NewMap[string, sqlschema.Column](
-				ordered.Pair[string, sqlschema.Column]{
-					Key: "id",
-					Value: &sqlschema.BaseColumn{
-						SQLType:      sqltype.VarChar,
-						DefaultValue: "random()",
-					},
+			want := []sqlschema.Column{
+				&sqlschema.BaseColumn{
+					Name:         "id",
+					SQLType:      sqltype.VarChar,
+					DefaultValue: "random()",
 				},
-				ordered.Pair[string, sqlschema.Column]{
-					Key: "name",
-					Value: &sqlschema.BaseColumn{
-						SQLType:      sqltype.VarChar,
-						DefaultValue: "John Doe",
-					},
+				&sqlschema.BaseColumn{
+					Name:         "name",
+					SQLType:      sqltype.VarChar,
+					DefaultValue: "John Doe",
 				},
-			)
+			}
 
 			got, err := inspector.Inspect(context.Background())
 			require.NoError(t, err)
@@ -562,28 +531,22 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 			tables.Register((*Model)(nil))
 			inspector := sqlschema.NewBunModelInspector(tables, sqlschema.WithSchemaName(dialect.DefaultSchema()))
 
-			want := ordered.NewMap[string, sqlschema.Column](
-				ordered.Pair[string, sqlschema.Column]{
-					Key: "id",
-					Value: &sqlschema.BaseColumn{
-						SQLType: "text",
-					},
+			want := []sqlschema.Column{
+				&sqlschema.BaseColumn{
+					Name:    "id",
+					SQLType: "text",
 				},
-				ordered.Pair[string, sqlschema.Column]{
-					Key: "first_name",
-					Value: &sqlschema.BaseColumn{
-						SQLType:    "character varying",
-						VarcharLen: 60,
-					},
+				&sqlschema.BaseColumn{
+					Name:       "first_name",
+					SQLType:    "character varying",
+					VarcharLen: 60,
 				},
-				ordered.Pair[string, sqlschema.Column]{
-					Key: "last_name",
-					Value: &sqlschema.BaseColumn{
-						SQLType:    "varchar",
-						VarcharLen: 100,
-					},
+				&sqlschema.BaseColumn{
+					Name:       "last_name",
+					SQLType:    "varchar",
+					VarcharLen: 100,
 				},
-			)
+			}
 
 			got, err := inspector.Inspect(context.Background())
 			require.NoError(t, err)

--- a/internal/dbtest/inspect_test.go
+++ b/internal/dbtest/inspect_test.go
@@ -79,197 +79,185 @@ func TestDatabaseInspector_Inspect(t *testing.T) {
 		for _, tt := range []struct {
 			name       string
 			schemaName string
-			wantTables *ordered.Map[string, sqlschema.Table]
+			wantTables []sqlschema.Table
 			wantFKs    []sqlschema.ForeignKey
 		}{
 			{
 				name:       "inspect default schema",
 				schemaName: defaultSchema,
 				// Tables come sorted alphabetically by schema and table.
-				wantTables: ordered.NewMap[string, sqlschema.Table](
+				wantTables: []sqlschema.Table{
 					// admin.offices should not be fetched, because it doesn't belong to the default schema.
-					ordered.Pair[string, sqlschema.Table]{
-						Key: "articles",
-						Value: &sqlschema.BaseTable{
-							Schema: defaultSchema,
-							Name:   "articles",
-							Columns: ordered.NewMap[string, sqlschema.Column](
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "isbn",
-									Value: &sqlschema.BaseColumn{
-										SQLType:         "bigint",
-										IsNullable:      false,
-										IsAutoIncrement: false,
-										IsIdentity:      true,
-										DefaultValue:    "",
-									},
+					&sqlschema.BaseTable{
+						Schema: defaultSchema,
+						Name:   "articles",
+						Columns: ordered.NewMap[string, sqlschema.Column](
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "isbn",
+								Value: &sqlschema.BaseColumn{
+									SQLType:         "bigint",
+									IsNullable:      false,
+									IsAutoIncrement: false,
+									IsIdentity:      true,
+									DefaultValue:    "",
 								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "editor",
-									Value: &sqlschema.BaseColumn{
-										SQLType:         sqltype.VarChar,
-										IsNullable:      false,
-										IsAutoIncrement: false,
-										IsIdentity:      false,
-										DefaultValue:    "john doe",
-									},
-								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "title",
-									Value: &sqlschema.BaseColumn{
-										SQLType:         sqltype.VarChar,
-										IsNullable:      false,
-										IsAutoIncrement: false,
-										IsIdentity:      false,
-										DefaultValue:    "",
-									},
-								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "locale",
-									Value: &sqlschema.BaseColumn{
-										SQLType:         sqltype.VarChar,
-										VarcharLen:      5,
-										IsNullable:      true,
-										IsAutoIncrement: false,
-										IsIdentity:      false,
-										DefaultValue:    "en-GB",
-									},
-								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "page_count",
-									Value: &sqlschema.BaseColumn{
-										SQLType:         "smallint",
-										IsNullable:      false,
-										IsAutoIncrement: false,
-										IsIdentity:      false,
-										DefaultValue:    "1",
-									},
-								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "book_count",
-									Value: &sqlschema.BaseColumn{
-										SQLType:         "integer",
-										IsNullable:      false,
-										IsAutoIncrement: true,
-										IsIdentity:      false,
-										DefaultValue:    "",
-									},
-								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "publisher_id",
-									Value: &sqlschema.BaseColumn{
-										SQLType: sqltype.VarChar,
-									},
-								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "author_id",
-									Value: &sqlschema.BaseColumn{
-										SQLType: "bigint",
-									},
-								},
-							),
-							PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("isbn")},
-							UniqueConstraints: []sqlschema.Unique{
-								{Columns: sqlschema.NewColumns("editor", "title")},
 							},
-						},
-					},
-					ordered.Pair[string, sqlschema.Table]{
-						Key: "authors",
-						Value: &sqlschema.BaseTable{
-							Schema: defaultSchema,
-							Name:   "authors",
-							Columns: ordered.NewMap[string, sqlschema.Column](
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "author_id",
-									Value: &sqlschema.BaseColumn{
-										SQLType:    "bigint",
-										IsIdentity: true,
-									},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "editor",
+								Value: &sqlschema.BaseColumn{
+									SQLType:         sqltype.VarChar,
+									IsNullable:      false,
+									IsAutoIncrement: false,
+									IsIdentity:      false,
+									DefaultValue:    "john doe",
 								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "first_name",
-									Value: &sqlschema.BaseColumn{
-										SQLType: sqltype.VarChar,
-									},
-								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "last_name",
-									Value: &sqlschema.BaseColumn{
-										SQLType: sqltype.VarChar,
-									},
-								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "email",
-									Value: &sqlschema.BaseColumn{
-										SQLType: sqltype.VarChar,
-									},
-								},
-							),
-							PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("author_id")},
-							UniqueConstraints: []sqlschema.Unique{
-								{Columns: sqlschema.NewColumns("first_name", "last_name")},
-								{Columns: sqlschema.NewColumns("email")},
 							},
-						},
-					},
-					ordered.Pair[string, sqlschema.Table]{
-						Key: "publisher_to_journalists",
-						Value: &sqlschema.BaseTable{
-							Schema: defaultSchema,
-							Name:   "publisher_to_journalists",
-							Columns: ordered.NewMap[string, sqlschema.Column](
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "publisher_id",
-									Value: &sqlschema.BaseColumn{
-										SQLType: sqltype.VarChar,
-									},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "title",
+								Value: &sqlschema.BaseColumn{
+									SQLType:         sqltype.VarChar,
+									IsNullable:      false,
+									IsAutoIncrement: false,
+									IsIdentity:      false,
+									DefaultValue:    "",
 								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "author_id",
-									Value: &sqlschema.BaseColumn{
-										SQLType: "bigint",
-									},
-								},
-							),
-							PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("publisher_id", "author_id")},
-						},
-					},
-					ordered.Pair[string, sqlschema.Table]{
-						Key: "publishers",
-						Value: &sqlschema.BaseTable{
-							Schema: defaultSchema,
-							Name:   "publishers",
-							Columns: ordered.NewMap[string, sqlschema.Column](
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "publisher_id",
-									Value: &sqlschema.BaseColumn{
-										SQLType:      sqltype.VarChar,
-										DefaultValue: "gen_random_uuid()",
-									},
-								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "publisher_name",
-									Value: &sqlschema.BaseColumn{
-										SQLType: sqltype.VarChar,
-									},
-								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "created_at",
-									Value: &sqlschema.BaseColumn{
-										SQLType:      "timestamp",
-										DefaultValue: "current_timestamp",
-										IsNullable:   true,
-									},
-								},
-							),
-							PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("publisher_id")},
-							UniqueConstraints: []sqlschema.Unique{
-								{Columns: sqlschema.NewColumns("publisher_id", "publisher_name")},
 							},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "locale",
+								Value: &sqlschema.BaseColumn{
+									SQLType:         sqltype.VarChar,
+									VarcharLen:      5,
+									IsNullable:      true,
+									IsAutoIncrement: false,
+									IsIdentity:      false,
+									DefaultValue:    "en-GB",
+								},
+							},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "page_count",
+								Value: &sqlschema.BaseColumn{
+									SQLType:         "smallint",
+									IsNullable:      false,
+									IsAutoIncrement: false,
+									IsIdentity:      false,
+									DefaultValue:    "1",
+								},
+							},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "book_count",
+								Value: &sqlschema.BaseColumn{
+									SQLType:         "integer",
+									IsNullable:      false,
+									IsAutoIncrement: true,
+									IsIdentity:      false,
+									DefaultValue:    "",
+								},
+							},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "publisher_id",
+								Value: &sqlschema.BaseColumn{
+									SQLType: sqltype.VarChar,
+								},
+							},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "author_id",
+								Value: &sqlschema.BaseColumn{
+									SQLType: "bigint",
+								},
+							},
+						),
+						PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("isbn")},
+						UniqueConstraints: []sqlschema.Unique{
+							{Columns: sqlschema.NewColumns("editor", "title")},
 						},
 					},
-				),
+					&sqlschema.BaseTable{
+						Schema: defaultSchema,
+						Name:   "authors",
+						Columns: ordered.NewMap[string, sqlschema.Column](
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "author_id",
+								Value: &sqlschema.BaseColumn{
+									SQLType:    "bigint",
+									IsIdentity: true,
+								},
+							},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "first_name",
+								Value: &sqlschema.BaseColumn{
+									SQLType: sqltype.VarChar,
+								},
+							},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "last_name",
+								Value: &sqlschema.BaseColumn{
+									SQLType: sqltype.VarChar,
+								},
+							},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "email",
+								Value: &sqlschema.BaseColumn{
+									SQLType: sqltype.VarChar,
+								},
+							},
+						),
+						PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("author_id")},
+						UniqueConstraints: []sqlschema.Unique{
+							{Columns: sqlschema.NewColumns("first_name", "last_name")},
+							{Columns: sqlschema.NewColumns("email")},
+						},
+					},
+					&sqlschema.BaseTable{
+						Schema: defaultSchema,
+						Name:   "publisher_to_journalists",
+						Columns: ordered.NewMap[string, sqlschema.Column](
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "publisher_id",
+								Value: &sqlschema.BaseColumn{
+									SQLType: sqltype.VarChar,
+								},
+							},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "author_id",
+								Value: &sqlschema.BaseColumn{
+									SQLType: "bigint",
+								},
+							},
+						),
+						PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("publisher_id", "author_id")},
+					},
+					&sqlschema.BaseTable{
+						Schema: defaultSchema,
+						Name:   "publishers",
+						Columns: ordered.NewMap[string, sqlschema.Column](
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "publisher_id",
+								Value: &sqlschema.BaseColumn{
+									SQLType:      sqltype.VarChar,
+									DefaultValue: "gen_random_uuid()",
+								},
+							},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "publisher_name",
+								Value: &sqlschema.BaseColumn{
+									SQLType: sqltype.VarChar,
+								},
+							},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "created_at",
+								Value: &sqlschema.BaseColumn{
+									SQLType:      "timestamp",
+									DefaultValue: "current_timestamp",
+									IsNullable:   true,
+								},
+							},
+						),
+						PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("publisher_id")},
+						UniqueConstraints: []sqlschema.Unique{
+							{Columns: sqlschema.NewColumns("publisher_id", "publisher_name")},
+						},
+					},
+				},
 				wantFKs: []sqlschema.ForeignKey{
 					{
 						From: sqlschema.NewColumnReference("articles", "publisher_id"),
@@ -292,38 +280,35 @@ func TestDatabaseInspector_Inspect(t *testing.T) {
 			{
 				name:       "inspect admin schema",
 				schemaName: "admin",
-				wantTables: ordered.NewMap[string, sqlschema.Table](
-					ordered.Pair[string, sqlschema.Table]{
-						Key: "offices",
-						Value: &sqlschema.BaseTable{
-							Schema: "admin",
-							Name:   "offices",
-							Columns: ordered.NewMap[string, sqlschema.Column](
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "office_name",
-									Value: &sqlschema.BaseColumn{
-										SQLType: sqltype.VarChar,
-									},
+				wantTables: []sqlschema.Table{
+					&sqlschema.BaseTable{
+						Schema: "admin",
+						Name:   "offices",
+						Columns: ordered.NewMap[string, sqlschema.Column](
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "office_name",
+								Value: &sqlschema.BaseColumn{
+									SQLType: sqltype.VarChar,
 								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "publisher_id",
-									Value: &sqlschema.BaseColumn{
-										SQLType:    sqltype.VarChar,
-										IsNullable: true,
-									},
+							},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "publisher_id",
+								Value: &sqlschema.BaseColumn{
+									SQLType:    sqltype.VarChar,
+									IsNullable: true,
 								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "publisher_name",
-									Value: &sqlschema.BaseColumn{
-										SQLType:    sqltype.VarChar,
-										IsNullable: true,
-									},
+							},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "publisher_name",
+								Value: &sqlschema.BaseColumn{
+									SQLType:    sqltype.VarChar,
+									IsNullable: true,
 								},
-							),
-							PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("office_name")},
-						},
+							},
+						),
+						PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("office_name")},
 					},
-				),
+				},
 				wantFKs: []sqlschema.ForeignKey{
 					{
 						From: sqlschema.NewColumnReference("offices", "publisher_name", "publisher_id"),
@@ -396,17 +381,28 @@ func mustCreateSchema(tb testing.TB, ctx context.Context, db *bun.DB, schema str
 func cmpTables(
 	tb testing.TB,
 	d sqlschema.InspectorDialect,
-	want, got *ordered.Map[string, sqlschema.Table],
+	want, got []sqlschema.Table,
 ) {
 	tb.Helper()
 
 	require.ElementsMatch(tb, tableNames(want), tableNames(got), "different set of tables")
 
 	// Now we are guaranteed to have the same tables.
-	for _, tPair := range want.Pairs() {
-		tableName, wantTable := tPair.Key, tPair.Value
-		gotTable, ok := got.Load(tableName)
-		require.True(tb, ok)
+	// They might still appear in a different order, here's a helper to find matching tables.
+	findGot := func(t testing.TB, name string) sqlschema.Table {
+		t.Helper()
+		for _, t := range got {
+			if t.GetName() == name {
+				return t
+			}
+		}
+		// This should never happen, as we've verified that table names match.
+		require.Fail(t, "cannot find table %q", name)
+		return nil
+	}
+
+	for _, wantTable := range want {
+		gotTable := findGot(tb, wantTable.GetName())
 		cmpColumns(tb, d, wantTable.GetName(), wantTable.GetColumns(), gotTable.GetColumns())
 		cmpConstraints(tb, wantTable.(*sqlschema.BaseTable), gotTable.(*sqlschema.BaseTable))
 	}
@@ -497,8 +493,11 @@ func cmpConstraints(tb testing.TB, want, got *sqlschema.BaseTable) {
 	require.ElementsMatch(tb, stripNames(want.UniqueConstraints), stripNames(got.UniqueConstraints), "table %q does not have expected unique constraints (listA=want, listB=got)", want.Name)
 }
 
-func tableNames(tables *ordered.Map[string, sqlschema.Table]) []string {
-	return tables.Keys()
+func tableNames(tables []sqlschema.Table) (names []string) {
+	for i := range tables {
+		names = append(names, tables[i].GetName())
+	}
+	return
 }
 
 func formatType(c sqlschema.Column) string {
@@ -545,8 +544,8 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 			require.NoError(t, err)
 
 			gotTables := got.GetTables()
-			require.Equal(t, 1, gotTables.Len())
-			for _, table := range gotTables.Values() {
+			require.Len(t, gotTables, 1)
+			for _, table := range gotTables {
 				cmpColumns(t, dialect.(sqlschema.InspectorDialect), "model", want, table.GetColumns())
 				return
 			}
@@ -590,8 +589,8 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 			require.NoError(t, err)
 
 			gotTables := got.GetTables()
-			require.Equal(t, 1, gotTables.Len())
-			for _, table := range gotTables.Values() {
+			require.Len(t, gotTables, 1)
+			for _, table := range gotTables {
 				cmpColumns(t, dialect.(sqlschema.InspectorDialect), "model", want, table.GetColumns())
 			}
 		})
@@ -619,8 +618,8 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 			require.NoError(t, err)
 
 			gotTables := got.GetTables()
-			require.Equal(t, 1, gotTables.Len())
-			for _, table := range gotTables.Values() {
+			require.Len(t, gotTables, 1)
+			for _, table := range gotTables {
 				cmpConstraints(t, want, &table.(*sqlschema.BunTable).BaseTable)
 				return
 			}
@@ -641,8 +640,8 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 			require.NoError(t, err)
 
 			gotTables := got.GetTables()
-			require.Equal(t, 1, gotTables.Len())
-			for _, table := range gotTables.Values() {
+			require.Len(t, gotTables, 1)
+			for _, table := range gotTables {
 				pk := table.GetPrimaryKey()
 				require.NotNilf(t, pk, "did not register primary key, want (%s)", want)
 				require.Equal(t, want, pk.Columns, "wrong primary key columns")
@@ -663,8 +662,8 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 			require.NoError(t, err)
 
 			gotTables := got.GetTables()
-			require.Equal(t, 1, gotTables.Len())
-			for _, table := range gotTables.Values() {
+			require.Len(t, gotTables, 1)
+			for _, table := range gotTables {
 				require.Equal(t, "custom_schema", table.GetSchema(), "wrong schema name")
 				require.Equal(t, "model", table.GetName(), "wrong table name")
 				return
@@ -688,8 +687,8 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 			require.NoError(t, err)
 
 			gotTables := got.GetTables()
-			require.Equal(t, 1, gotTables.Len())
-			for _, table := range gotTables.Values() {
+			require.Len(t, gotTables, 1)
+			for _, table := range gotTables {
 				require.Equal(t, "want", table.GetSchema(), "wrong schema name")
 				require.Equal(t, "keep_me", table.GetName(), "wrong table name")
 				return

--- a/migrate/diff.go
+++ b/migrate/diff.go
@@ -1,6 +1,7 @@
 package migrate
 
 import (
+	"github.com/uptrace/bun/internal/ordered"
 	"github.com/uptrace/bun/migrate/sqlschema"
 )
 
@@ -22,8 +23,8 @@ func diff(got, want sqlschema.Database, opts ...diffOption) *changeset {
 }
 
 func (d *detector) detectChanges() *changeset {
-	currentTables := d.current.GetTables()
-	targetTables := d.target.GetTables()
+	currentTables := toOrderedMap(d.current.GetTables())
+	targetTables := toOrderedMap(d.target.GetTables())
 
 RenameCreate:
 	for _, wantPair := range targetTables.Pairs() {
@@ -97,6 +98,15 @@ RenameCreate:
 	}
 
 	return &d.changes
+}
+
+// toOrderedMap transforms a slice of objects to an ordered map, using return of GetName() as key.
+func toOrderedMap[V interface{ GetName() string }](named []V) *ordered.Map[string, V] {
+	m := ordered.NewMap[string, V]()
+	for _, v := range named {
+		m.Store(v.GetName(), v)
+	}
+	return m
 }
 
 // detechColumnChanges finds renamed columns and, if checkType == true, columns with changed type.
@@ -311,7 +321,6 @@ func equalSignatures(t1, t2 sqlschema.Table, eq CompareTypeFunc) bool {
 // signature is a set of column definitions, which allows "relation/name-agnostic" comparison between them;
 // meaning that two columns are considered equal if their types are the same.
 type signature struct {
-
 	// underlying stores the number of occurences for each unique column type.
 	// It helps to account for the fact that a table might have multiple columns that have the same type.
 	underlying map[sqlschema.BaseColumn]int

--- a/migrate/diff.go
+++ b/migrate/diff.go
@@ -111,8 +111,8 @@ func toOrderedMap[V interface{ GetName() string }](named []V) *ordered.Map[strin
 
 // detechColumnChanges finds renamed columns and, if checkType == true, columns with changed type.
 func (d *detector) detectColumnChanges(current, target sqlschema.Table, checkType bool) {
-	currentColumns := current.GetColumns()
-	targetColumns := target.GetColumns()
+	currentColumns := toOrderedMap(current.GetColumns())
+	targetColumns := toOrderedMap(target.GetColumns())
 
 ChangeRename:
 	for _, tPair := range targetColumns.Pairs() {
@@ -339,7 +339,7 @@ func newSignature(t sqlschema.Table, eq CompareTypeFunc) signature {
 
 // scan iterates over table's field and counts occurrences of each unique column definition.
 func (s *signature) scan(t sqlschema.Table) {
-	for _, icol := range t.GetColumns().Values() {
+	for _, icol := range t.GetColumns() {
 		scanCol := icol.(*sqlschema.BaseColumn)
 		// This is slightly more expensive than if the columns could be compared directly
 		// and we always did s.underlying[col]++, but we get type-equivalence in return.

--- a/migrate/sqlschema/database.go
+++ b/migrate/sqlschema/database.go
@@ -4,12 +4,11 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/uptrace/bun/internal/ordered"
 	"github.com/uptrace/bun/schema"
 )
 
 type Database interface {
-	GetTables() *ordered.Map[string, Table]
+	GetTables() []Table
 	GetForeignKeys() map[ForeignKey]string
 }
 
@@ -20,11 +19,11 @@ var _ Database = (*BaseDatabase)(nil)
 // Dialects and only dialects can use it to implement the Database interface.
 // Other packages must use the Database interface.
 type BaseDatabase struct {
-	Tables      *ordered.Map[string, Table]
+	Tables      []Table
 	ForeignKeys map[ForeignKey]string
 }
 
-func (ds BaseDatabase) GetTables() *ordered.Map[string, Table] {
+func (ds BaseDatabase) GetTables() []Table {
 	return ds.Tables
 }
 

--- a/migrate/sqlschema/inspector.go
+++ b/migrate/sqlschema/inspector.go
@@ -126,7 +126,6 @@ func (bmi *BunModelInspector) Inspect(ctx context.Context) (Database, error) {
 		BaseDatabase: BaseDatabase{
 			ForeignKeys: make(map[ForeignKey]string),
 		},
-		Tables: ordered.NewMap[string, Table](),
 	}
 	for _, t := range bmi.tables.All() {
 		if t.Schema != bmi.SchemaName {
@@ -186,7 +185,7 @@ func (bmi *BunModelInspector) Inspect(ctx context.Context) (Database, error) {
 		// produces
 		// 	schema.Table{ Schema: "favourite", Name: "favourite.books" }
 		tableName := strings.TrimPrefix(t.Name, t.Schema+".")
-		state.Tables.Store(tableName, &BunTable{
+		state.Tables = append(state.Tables, &BunTable{
 			BaseTable: BaseTable{
 				Schema:            t.Schema,
 				Name:              tableName,
@@ -236,7 +235,7 @@ func parseLen(typ string) (string, int, error) {
 }
 
 // exprOrLiteral converts string to lowercase, if it does not contain a string literal 'lit'
-// and trims the surrounding '' otherwise.
+// and trims the surrounding ” otherwise.
 // Use it to ensure that user-defined default values in the models are always comparable
 // to those returned by the database inspector, regardless of the case convention in individual drivers.
 func exprOrLiteral(s string) string {
@@ -250,10 +249,10 @@ func exprOrLiteral(s string) string {
 type BunModelSchema struct {
 	BaseDatabase
 
-	Tables *ordered.Map[string, Table]
+	Tables []Table
 }
 
-func (ms BunModelSchema) GetTables() *ordered.Map[string, Table] {
+func (ms BunModelSchema) GetTables() []Table {
 	return ms.Tables
 }
 

--- a/migrate/sqlschema/inspector.go
+++ b/migrate/sqlschema/inspector.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/uptrace/bun"
-	"github.com/uptrace/bun/internal/ordered"
 	"github.com/uptrace/bun/schema"
 )
 
@@ -132,14 +131,14 @@ func (bmi *BunModelInspector) Inspect(ctx context.Context) (Database, error) {
 			continue
 		}
 
-		columns := ordered.NewMap[string, Column]()
+		var columns []Column
 		for _, f := range t.Fields {
 
 			sqlType, length, err := parseLen(f.CreateTableSQLType)
 			if err != nil {
 				return nil, fmt.Errorf("parse length in %q: %w", f.CreateTableSQLType, err)
 			}
-			columns.Store(f.Name, &BaseColumn{
+			columns = append(columns, &BaseColumn{
 				Name:            f.Name,
 				SQLType:         strings.ToLower(sqlType), // TODO(dyma): maybe this is not necessary after Column.Eq()
 				VarcharLen:      length,

--- a/migrate/sqlschema/table.go
+++ b/migrate/sqlschema/table.go
@@ -1,13 +1,9 @@
 package sqlschema
 
-import (
-	"github.com/uptrace/bun/internal/ordered"
-)
-
 type Table interface {
 	GetSchema() string
 	GetName() string
-	GetColumns() *ordered.Map[string, Column]
+	GetColumns() []Column
 	GetPrimaryKey() *PrimaryKey
 	GetUniqueConstraints() []Unique
 }
@@ -23,7 +19,7 @@ type BaseTable struct {
 	Name   string
 
 	// ColumnDefinitions map each column name to the column definition.
-	Columns *ordered.Map[string, Column]
+	Columns []Column
 
 	// PrimaryKey holds the primary key definition.
 	// A nil value means that no primary key is defined for the table.
@@ -47,7 +43,7 @@ func (td *BaseTable) GetName() string {
 	return td.Name
 }
 
-func (td *BaseTable) GetColumns() *ordered.Map[string, Column] {
+func (td *BaseTable) GetColumns() []Column {
 	return td.Columns
 }
 


### PR DESCRIPTION
This PR addresses one of the issues raised [here](https://github.com/uptrace/bun/pull/926#issuecomment-2758161051):

> One piece of feedback regarding ordered.Map as a dependency [...] The choice to use an internal type in exported fields of exported structs made this code unusable as is, and made extending and building upon it really really messy.

Indeed, `Database`, `Table`, and `BunModelSchema` (with Tables field) are all exported members of `sqlschema` package. Having them return `internal/ordered.Map` has several implications:

1. As noted in the comment, external packages aren't able to use return of Tables(), while other methods, e.g. ForeignKeys() return usable objects. Same is true for `Columns()`.

2. Since `sqlschema` requires _dialects_ to use/return `ordered.Map`, no otherwise compatible 3rd-party dialect will be able to implement `sqlschema.Inspector`

We've originally decided to use an ordered map to [achieve stable query generation](https://github.com/uptrace/bun/pull/926#issuecomment-2466687386), which really is a great use case for it.

This PR limits the usage of the ordered map to where it's most useful -- the `migrate.detector`, which calculates schema diff. Meanwhile, schema inspectors will return Tables and Columns as slices, reducing the complexity and making the package more extendable and interoperable.  

Some of the tests got a tiny bit more verbose as a result, but overall the code looks simpler. 
