### PR TITLE
chore: rename migrate.comment to migrate.Unimplemented

### DIFF
--- a/migrate/auto.go
+++ b/migrate/auto.go
@@ -352,7 +352,7 @@ func (c *changeset) apply(ctx context.Context, db *bun.DB, m sqlschema.Migrator)
 	}
 
 	for _, op := range c.operations {
-		if _, isComment := op.(*comment); isComment {
+		if _, skip := op.(*Unimplemented); skip {
 			continue
 		}
 
@@ -375,9 +375,9 @@ func (c *changeset) WriteTo(w io.Writer, m sqlschema.Migrator) error {
 
 	b := internal.MakeQueryBytes()
 	for _, op := range c.operations {
-		if c, isComment := op.(*comment); isComment {
+		if comment, isComment := op.(*Unimplemented); isComment {
 			b = append(b, "/*\n"...)
-			b = append(b, *c...)
+			b = append(b, *comment...)
 			b = append(b, "\n*/"...)
 			continue
 		}

--- a/migrate/operations.go
+++ b/migrate/operations.go
@@ -56,7 +56,7 @@ func (op *DropTableOp) DependsOn(another Operation) bool {
 // GetReverse for a DropTable returns a no-op migration. Logically, CreateTable is the reverse,
 // but DropTable does not have the table's definition to create one.
 func (op *DropTableOp) GetReverse() Operation {
-	c := comment(fmt.Sprintf("WARNING: \"DROP TABLE %s\" cannot be reversed automatically because table definition is not available", op.TableName))
+	c := Unimplemented(fmt.Sprintf("WARNING: \"DROP TABLE %s\" cannot be reversed automatically because table definition is not available", op.TableName))
 	return &c
 }
 
@@ -224,7 +224,6 @@ func (op *AddUniqueConstraintOp) DependsOn(another Operation) bool {
 	default:
 		return false
 	}
-
 }
 
 // DropUniqueConstraintOp drops a UNIQUE constraint.
@@ -326,15 +325,15 @@ func (op *ChangePrimaryKeyOp) GetReverse() Operation {
 	}
 }
 
-// comment denotes an Operation that cannot be executed.
+// Unimplemented denotes an Operation that cannot be executed.
 //
 // Operations, which cannot be reversed due to current technical limitations,
-// may return &comment with a helpful message from their GetReverse() method.
+// may have their GetReverse() return &Unimplemented with a helpful message.
 //
-// Chnagelog should skip it when applying operations or output as log message,
-// and write it as an SQL comment when creating migration files.
-type comment string
+// When applying operations, changelog should skip it or output as a log message,
+// and write it as an SQL Unimplemented when creating migration files.
+type Unimplemented string
 
-var _ Operation = (*comment)(nil)
+var _ Operation = (*Unimplemented)(nil)
 
-func (c *comment) GetReverse() Operation { return c }
+func (reason *Unimplemented) GetReverse() Operation { return reason }


### PR DESCRIPTION
Another follow up to [this comment](https://github.com/uptrace/bun/pull/926#issuecomment-2758161051) in #926:

> Also, it would be handy for migrate.comment to be an exported type. As it is, I had to use reflection to detect them.

All other operations are exported types with exported fields. We can export comment as well to make 'migrate' package more extendable / interoperable.