### PR TITLE
feat(pgdriver): add overflow handler to listener channel

### DIFF
--- a/driver/pgdriver/listener_test.go
+++ b/driver/pgdriver/listener_test.go
@@ -1,0 +1,28 @@
+package pgdriver
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithChannelOverflowHandler(t *testing.T) {
+	// Create a test handler
+	testHandler := func(n Notification) {}
+
+	// Create a channel instance
+	c := &channel{}
+
+	// Apply the option
+	opt := WithChannelOverflowHandler(testHandler)
+	opt(c)
+
+	// Verify the handler was set correctly
+	assert.NotNil(t, c.overflowHandler, "overflow handler should be set")
+	assert.Equal(t,
+		reflect.ValueOf(testHandler).Pointer(),
+		reflect.ValueOf(c.overflowHandler).Pointer(),
+		"overflow handler should match the provided handler",
+	)
+}


### PR DESCRIPTION
This PR enables handling overflow scenarios in PostgreSQL LISTEN/NOTIFY channels by introducing a custom overflow handler option.

### Changes

- Added `WithChannelOverflowHandler` option to configure custom handling of dropped messages
- Added `channelOverflowHandler` type for handling overflow notifications
- Updated channel implementation to use the overflow handler when the buffer is full

### Example Usage

```go
ln := pgdriver.NewListener(db)

// Create a channel with custom overflow handling
ch := ln.Channel(
    pgdriver.WithChannelSize(100),
    pgdriver.WithChannelOverflowHandler(func(n pgdriver.Notification) {
        // Handle overflow notifications:
        // - Store in a database
        // - Send to a dead letter queue
        // - Log to a monitoring system
        // - Implement retry logic
        // - etc.
    }),
)
```

### Benefits

- Provides flexibility in handling overflow scenarios
- Allows implementing custom recovery strategies
- Enables integration with existing monitoring/logging systems
- Prevents silent message drops by allowing custom handling

Note: I am building a custom pub-sub for [watermill](https://watermill.io/pubsubs/sql/) that uses a push strategy (PostgreSQL LISTEN/NOTIFY) instead of pull, and I want to use Bun as the default db adapter.