### PR TITLE
feat(migrations): support Go templates in SQL migrations

### DIFF
--- a/example/migrate/main.go
+++ b/example/migrate/main.go
@@ -30,11 +30,14 @@ func main() {
 		bundebug.FromEnv(),
 	))
 
+	templateData := map[string]string{
+		"Prefix": "example_",
+	}
 	app := &cli.App{
 		Name: "bun",
 
 		Commands: []*cli.Command{
-			newDBCommand(migrate.NewMigrator(db, migrations.Migrations)),
+			newDBCommand(migrate.NewMigrator(db, migrations.Migrations, migrate.WithTemplateData(templateData))),
 		},
 	}
 	if err := app.Run(os.Args); err != nil {

--- a/example/migrate/migrations/20210505110847_bar.down.sql
+++ b/example/migrate/migrations/20210505110847_bar.down.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS test;
+DROP TABLE IF EXISTS {{.Prefix}}test;

--- a/example/migrate/migrations/20210505110847_bar.up.sql
+++ b/example/migrate/migrations/20210505110847_bar.up.sql
@@ -1,7 +1,7 @@
-CREATE TABLE test (
+CREATE TABLE {{.Prefix}}test (
   id bigint PRIMARY KEY
 );
 
 --bun:split
 
-ALTER TABLE test ADD COLUMN name varchar(100);
+ALTER TABLE {{.Prefix}}test ADD COLUMN name varchar(100);

--- a/internal/dbtest/migrate_test.go
+++ b/internal/dbtest/migrate_test.go
@@ -76,22 +76,22 @@ func testMigrateUpAndDown(t *testing.T, db *bun.DB) {
 	migrations := migrate.NewMigrations()
 	migrations.Add(migrate.Migration{
 		Name: "20060102150405",
-		Up: func(ctx context.Context, db *bun.DB) error {
+		Up: func(ctx context.Context, db *bun.DB, templateData any) error {
 			history = append(history, "up1")
 			return nil
 		},
-		Down: func(ctx context.Context, db *bun.DB) error {
+		Down: func(ctx context.Context, db *bun.DB, templateData any) error {
 			history = append(history, "down1")
 			return nil
 		},
 	})
 	migrations.Add(migrate.Migration{
 		Name: "20060102160405",
-		Up: func(ctx context.Context, db *bun.DB) error {
+		Up: func(ctx context.Context, db *bun.DB, templateData any) error {
 			history = append(history, "up2")
 			return nil
 		},
-		Down: func(ctx context.Context, db *bun.DB) error {
+		Down: func(ctx context.Context, db *bun.DB, templateData any) error {
 			history = append(history, "down2")
 			return nil
 		},
@@ -126,33 +126,33 @@ func testMigrateUpError(t *testing.T, db *bun.DB) {
 	migrations := migrate.NewMigrations()
 	migrations.Add(migrate.Migration{
 		Name: "20060102150405",
-		Up: func(ctx context.Context, db *bun.DB) error {
+		Up: func(ctx context.Context, db *bun.DB, templateData any) error {
 			history = append(history, "up1")
 			return nil
 		},
-		Down: func(ctx context.Context, db *bun.DB) error {
+		Down: func(ctx context.Context, db *bun.DB, templateData any) error {
 			history = append(history, "down1")
 			return nil
 		},
 	})
 	migrations.Add(migrate.Migration{
 		Name: "20060102160405",
-		Up: func(ctx context.Context, db *bun.DB) error {
+		Up: func(ctx context.Context, db *bun.DB, templateData any) error {
 			history = append(history, "up2")
 			return errors.New("failed")
 		},
-		Down: func(ctx context.Context, db *bun.DB) error {
+		Down: func(ctx context.Context, db *bun.DB, templateData any) error {
 			history = append(history, "down2")
 			return nil
 		},
 	})
 	migrations.Add(migrate.Migration{
 		Name: "20060102170405",
-		Up: func(ctx context.Context, db *bun.DB) error {
+		Up: func(ctx context.Context, db *bun.DB, templateData any) error {
 			history = append(history, "up3")
 			return errors.New("failed")
 		},
-		Down: func(ctx context.Context, db *bun.DB) error {
+		Down: func(ctx context.Context, db *bun.DB, templateData any) error {
 			history = append(history, "down3")
 			return nil
 		},

--- a/migrate/auto.go
+++ b/migrate/auto.go
@@ -268,8 +268,8 @@ func (am *AutoMigrator) createSQLMigrations(ctx context.Context, transactional b
 	migrations := NewMigrations(am.migrationsOpts...)
 	migrations.Add(Migration{
 		Name:    name,
-		Up:      changes.Up(am.dbMigrator),
-		Down:    changes.Down(am.dbMigrator),
+		Up:      wrapMigrationFunc(changes.Up(am.dbMigrator)),
+		Down:    wrapMigrationFunc(changes.Down(am.dbMigrator)),
 		Comment: "Changes detected by bun.AutoMigrator",
 	})
 

--- a/migrate/migration.go
+++ b/migrate/migration.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"sort"
 	"strings"
+	"text/template"
 	"time"
 
 	"github.com/uptrace/bun"
@@ -23,8 +24,8 @@ type Migration struct {
 	GroupID    int64
 	MigratedAt time.Time `bun:",notnull,nullzero,default:current_timestamp"`
 
-	Up   MigrationFunc `bun:"-"`
-	Down MigrationFunc `bun:"-"`
+	Up   internalMigrationFunc `bun:"-"`
+	Down internalMigrationFunc `bun:"-"`
 }
 
 func (m Migration) String() string {
@@ -35,23 +36,57 @@ func (m Migration) IsApplied() bool {
 	return m.ID > 0
 }
 
+type internalMigrationFunc func(ctx context.Context, db *bun.DB, templateData any) error
+
 type MigrationFunc func(ctx context.Context, db *bun.DB) error
 
-func NewSQLMigrationFunc(fsys fs.FS, name string) MigrationFunc {
-	return func(ctx context.Context, db *bun.DB) error {
+func NewSQLMigrationFunc(fsys fs.FS, name string) internalMigrationFunc {
+	return func(ctx context.Context, db *bun.DB, templateData any) error {
 		f, err := fsys.Open(name)
 		if err != nil {
 			return err
 		}
 
 		isTx := strings.HasSuffix(name, ".tx.up.sql") || strings.HasSuffix(name, ".tx.down.sql")
-		return Exec(ctx, db, f, isTx)
+		return Exec(ctx, db, f, templateData, isTx)
 	}
 }
 
+func wrapMigrationFunc(fn MigrationFunc) internalMigrationFunc {
+	return func(ctx context.Context, db *bun.DB, templateData any) error {
+		return fn(ctx, db)
+	}
+}
+
+func prepareTemplate(f io.Reader, templateData any) (*bytes.Buffer, error) {
+	contents, err := io.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+
+	tmpl, err := template.New("migration").Parse(string(contents))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse template: %w", err)
+	}
+
+	var rendered bytes.Buffer
+	if templateData == nil {
+		templateData = struct{}{}
+	}
+	if err := tmpl.Execute(&rendered, templateData); err != nil {
+		return nil, fmt.Errorf("failed to execute template: %w", err)
+	}
+
+	return &rendered, nil
+}
+
 // Exec reads and executes the SQL migration in the f.
-func Exec(ctx context.Context, db *bun.DB, f io.Reader, isTx bool) error {
-	scanner := bufio.NewScanner(f)
+func Exec(ctx context.Context, db *bun.DB, f io.Reader, templateData any, isTx bool) error {
+	rendered, err := prepareTemplate(f, templateData)
+	if err != nil {
+		return err
+	}
+	scanner := bufio.NewScanner(rendered)
 	var queries []string
 
 	var query []byte

--- a/migrate/migrations.go
+++ b/migrate/migrations.go
@@ -58,8 +58,8 @@ func (m *Migrations) Register(up, down MigrationFunc) error {
 	m.Add(Migration{
 		Name:    name,
 		Comment: comment,
-		Up:      up,
-		Down:    down,
+		Up:      wrapMigrationFunc(up),
+		Down:    wrapMigrationFunc(down),
 	})
 
 	return nil

--- a/migrate/migrator.go
+++ b/migrate/migrator.go
@@ -41,6 +41,12 @@ func WithMarkAppliedOnSuccess(enabled bool) MigratorOption {
 	}
 }
 
+func WithTemplateData(data any) MigratorOption {
+	return func(m *Migrator) {
+		m.templateData = data
+	}
+}
+
 type Migrator struct {
 	db         *bun.DB
 	migrations *Migrations
@@ -50,6 +56,8 @@ type Migrator struct {
 	table                string
 	locksTable           string
 	markAppliedOnSuccess bool
+
+	templateData any
 }
 
 func NewMigrator(db *bun.DB, migrations *Migrations, opts ...MigratorOption) *Migrator {
@@ -168,7 +176,7 @@ func (m *Migrator) Migrate(ctx context.Context, opts ...MigrationOption) (*Migra
 		group.Migrations = migrations[:i+1]
 
 		if !cfg.nop && migration.Up != nil {
-			if err := migration.Up(ctx, m.db); err != nil {
+			if err := migration.Up(ctx, m.db, m.templateData); err != nil {
 				return group, err
 			}
 		}
@@ -207,7 +215,7 @@ func (m *Migrator) Rollback(ctx context.Context, opts ...MigrationOption) (*Migr
 		}
 
 		if !cfg.nop && migration.Down != nil {
-			if err := migration.Down(ctx, m.db); err != nil {
+			if err := migration.Down(ctx, m.db, m.templateData); err != nil {
 				return lastGroup, err
 			}
 		}


### PR DESCRIPTION
## Summary

This PR adds support for rendering `.sql` migration files as Go templates via `text/template`.  
You can now inject dynamic data into your SQL using a new migrator option: `WithTemplateData`.


## Usage

Pass your data using the new option:

```go
templateData := map[string]string{
    "Prefix": "example_",
}

migrator := migrate.NewMigrator(db, migrations.Migrations, migrate.WithTemplateData(templateData))
```

And in your .sql file:
```sql
CREATE TABLE {{.Prefix}}users (
    id BIGINT PRIMARY KEY
);

--bun:split

ALTER TABLE {{.Prefix}}users ADD COLUMN name VARCHAR(100);
```

## Changes
- `WithTemplateData(data any)` provides template data to be rendered inside .sql migration files
- `internalMigrationFunc` introduced to wrap `MigrationFunc` with template context
- `.sql` files are parsed using text/template before execution
- Template rendering is fully optional and backward-compatible
- Updated example: `example/migrate/main.go`
- Added test template in: `example/migrate/migrations/*.sql`
