### PR TITLE
fix(automigrate): improve migrations on `autoincrement` columns

### DIFF
--- a/dialect/pgdialect/alter_table.go
+++ b/dialect/pgdialect/alter_table.go
@@ -1,6 +1,7 @@
 package pgdialect
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -57,6 +58,11 @@ func (m *migrator) AppendSQL(b []byte, operation interface{}) (_ []byte, err err
 	case *migrate.DropUniqueConstraintOp:
 		b, err = m.dropConstraint(fmter, appendAlterTable(b, change.TableName), change.Unique.Name)
 	case *migrate.ChangeColumnTypeOp:
+		// If column changes to SERIAL, create sequence first.
+		// https://gist.github.com/oleglomako/185df689706c5499612a0d54d3ffe856
+		if !change.From.GetIsAutoIncrement() && change.To.GetIsAutoIncrement() {
+			change.To, b, err = m.createDefaultSequence(fmter, b, change)
+		}
 		b, err = m.changeColumnType(fmter, appendAlterTable(b, change.TableName), change)
 	case *migrate.AddForeignKeyOp:
 		b, err = m.addForeignKey(fmter, appendAlterTable(b, change.TableName()), change)
@@ -185,6 +191,41 @@ func (m *migrator) addForeignKey(fmter schema.Formatter, b []byte, add *migrate.
 	b = append(b, ")"...)
 
 	return b, nil
+}
+
+// createDefaultSequence creates a SEQUENCE to back a serial column.
+// Having a backing sequence is necessary to change column type to SERIAL.
+// The updated Column's default is  set to "nextval" of the new sequence.
+func (m *migrator) createDefaultSequence(_ schema.Formatter, b []byte, op *migrate.ChangeColumnTypeOp) (_ sqlschema.Column, _ []byte, err error) {
+	var start int
+	if err = m.db.NewSelect().Table(op.TableName).
+		ColumnExpr("MAX(?)", op.Column).Scan(context.TODO(), &start); err != nil {
+		return nil, b, err
+	}
+	start = max(start, 1) // cannot be less than 1
+
+	seq := op.TableName + "_" + op.Column + "_seq"
+	fqn := op.TableName + "." + op.Column
+
+	// A sequence that is OWNED BY a table will be dropped
+	// if the table is dropped with CASCADE action.
+	b = append(b, "CREATE SEQUENCE "...)
+	b = append(b, seq...)
+	b = append(b, " START WITH "...)
+	b = append(b, fmt.Sprint(start)...)
+	b = append(b, " OWNED BY "...)
+	b = append(b, fqn...)
+	b = append(b, ";\n"...)
+
+	return &Column{
+		Name:            op.To.GetName(),
+		SQLType:         op.To.GetSQLType(),
+		VarcharLen:      op.To.GetVarcharLen(),
+		DefaultValue:    fmt.Sprintf("nextval('%s'::regclass)", seq),
+		IsNullable:      op.To.GetIsNullable(),
+		IsAutoIncrement: op.To.GetIsAutoIncrement(),
+		IsIdentity:      op.To.GetIsIdentity(),
+	}, b, nil
 }
 
 func (m *migrator) changeColumnType(fmter schema.Formatter, b []byte, colDef *migrate.ChangeColumnTypeOp) (_ []byte, err error) {

--- a/dialect/pgdialect/sqltype.go
+++ b/dialect/pgdialect/sqltype.go
@@ -127,6 +127,9 @@ var (
 	char        = newAliases(pgTypeChar, pgTypeCharacter)
 	varchar     = newAliases(pgTypeVarchar, pgTypeCharacterVarying)
 	timestampTz = newAliases(sqltype.Timestamp, pgTypeTimestampTz, pgTypeTimestampWithTz)
+	bigint      = newAliases(sqltype.BigInt, pgTypeBigSerial)
+	integer     = newAliases(sqltype.Integer, pgTypeSerial)
+	smallint    = newAliases(sqltype.SmallInt, pgTypeSmallSerial)
 )
 
 func (d *Dialect) CompareType(col1, col2 sqlschema.Column) bool {
@@ -142,6 +145,10 @@ func (d *Dialect) CompareType(col1, col2 sqlschema.Column) bool {
 	case varchar.IsAlias(typ1) && varchar.IsAlias(typ2):
 		return checkVarcharLen(col1, col2, d.DefaultVarcharLen())
 	case timestampTz.IsAlias(typ1) && timestampTz.IsAlias(typ2):
+		return true
+	case bigint.IsAlias(typ1) && bigint.IsAlias(typ2),
+		integer.IsAlias(typ1) && integer.IsAlias(typ2),
+		smallint.IsAlias(typ1) && smallint.IsAlias(typ2):
 		return true
 	}
 	return false

--- a/dialect/pgdialect/sqltype_test.go
+++ b/dialect/pgdialect/sqltype_test.go
@@ -35,6 +35,11 @@ func TestInspectorDialect_CompareType(t *testing.T) {
 			{sqltype.Timestamp, pgTypeTimestamp, true}, // Still, TIMESTAMP == TIMESTAMP
 			{sqltype.Timestamp, pgTypeTimeTz, false},
 			{pgTypeTimestampTz, pgTypeTimestampWithTz, true},
+
+			// SERIAL is an alias to INT + auto-generated sequence
+			{sqltype.BigInt, pgTypeBigSerial, true},
+			{sqltype.Integer, pgTypeSerial, true},
+			{sqltype.SmallInt, pgTypeSmallSerial, true},
 		} {
 			eq := " ~ "
 			if !tt.want {
@@ -48,7 +53,6 @@ func TestInspectorDialect_CompareType(t *testing.T) {
 				require.Equal(t, tt.want, got)
 			})
 		}
-
 	})
 
 	t.Run("custom varchar length", func(t *testing.T) {

--- a/internal/dbtest/migrate_test.go
+++ b/internal/dbtest/migrate_test.go
@@ -700,7 +700,7 @@ func testAddDropColumn(t *testing.T, db *bun.DB) {
 	type TableAfter struct {
 		bun.BaseModel `bun:"table:column_madness"`
 		DoNotTouch    string `bun:"do_not_touch"`
-		AddMe         bool   `bun:"addme"`
+		AddMe         int64  `bun:"addme,autoincrement"`
 	}
 
 	wantTables := []sqlschema.Table{
@@ -714,9 +714,10 @@ func testAddDropColumn(t *testing.T, db *bun.DB) {
 					IsNullable: true,
 				},
 				&sqlschema.BaseColumn{
-					Name:       "addme",
-					SQLType:    sqltype.Boolean,
-					IsNullable: true,
+					Name:            "addme",
+					SQLType:         sqltype.BigInt,
+					IsNullable:      false,
+					IsAutoIncrement: true,
 				},
 			},
 		},

--- a/internal/dbtest/migrate_test.go
+++ b/internal/dbtest/migrate_test.go
@@ -1033,7 +1033,7 @@ func testNothingToMigrate(t *testing.T, db *bun.DB) {
 		AlwaysBlue string `bun:"colour,default:'blue'"`
 
 		// Check that no superficial migrations are generated for `autoincrement` columns.
-		BigInt int64 `bun:",autoincrement"`
+		BigInt int64 `bun:",pk,autoincrement"`
 	}
 
 	ctx := context.Background()

--- a/internal/dbtest/migrate_test.go
+++ b/internal/dbtest/migrate_test.go
@@ -569,6 +569,7 @@ func testChangeColumnType_AutoCast(t *testing.T, db *bun.DB) {
 		EmptyDefault string    `bun:"empty_default"`
 		Nullable     string    `bun:"not_null"`
 		TypeOverride string    `bun:"type:varchar(100)"`
+		Incremented  int       `bun:"incremented"`
 		// ManyValues    []string  `bun:",array"`
 	}
 
@@ -581,6 +582,7 @@ func testChangeColumnType_AutoCast(t *testing.T, db *bun.DB) {
 		EmptyDefault string    `bun:"empty_default,default:''"`      // '' empty string default
 		NotNullable  string    `bun:"not_null,notnull"`              // added NOT NULL
 		TypeOverride string    `bun:"type:varchar(200)"`             // new length
+		Incremented  int       `bun:"incremented,autoincrement"`     // make autoincremented
 		// ManyValues    []string  `bun:",array"`                    // did not change
 	}
 
@@ -622,6 +624,12 @@ func testChangeColumnType_AutoCast(t *testing.T, db *bun.DB) {
 					SQLType:    "varchar",
 					IsNullable: true,
 					VarcharLen: 200,
+				},
+				&sqlschema.BaseColumn{
+					Name:            "incremented",
+					SQLType:         "bigint",
+					IsNullable:      false,
+					IsAutoIncrement: true,
 				},
 				// &sqlschema.BaseColumn{
 				// 	Name:    "many_values",

--- a/internal/dbtest/migrate_test.go
+++ b/internal/dbtest/migrate_test.go
@@ -1033,9 +1033,7 @@ func testNothingToMigrate(t *testing.T, db *bun.DB) {
 		AlwaysBlue string `bun:"colour,default:'blue'"`
 
 		// Check that no superficial migrations are generated for `autoincrement` columns.
-		BigInt   int64 `bun:",autoincrement"`
-		Int      int32 `bun:",autoincrement"`
-		SmallInt int16 `bun:",autoincrement"`
+		BigInt int64 `bun:",autoincrement"`
 	}
 
 	ctx := context.Background()

--- a/internal/dbtest/migrate_test.go
+++ b/internal/dbtest/migrate_test.go
@@ -1045,10 +1045,10 @@ func testNothingToMigrate(t *testing.T, db *bun.DB) {
 	}
 
 	ctx := context.Background()
-	mustResetModel(t, ctx, db, (*BoringThing)(nil))
 	m := newAutoMigratorOrSkip(t, db,
 		migrate.WithModel((*BoringThing)(nil)),
 	)
+	mustResetModel(t, ctx, db, (*BoringThing)(nil))
 
 	// Act
 	_, err := m.Migrate(ctx) // do not use runMigrations because we do not expect any files to be created

--- a/internal/dbtest/migrate_test.go
+++ b/internal/dbtest/migrate_test.go
@@ -1030,6 +1030,11 @@ func testUpdatePrimaryKeys(t *testing.T, db *bun.DB) {
 func testNothingToMigrate(t *testing.T, db *bun.DB) {
 	type BoringThing struct {
 		AlwaysBlue string `bun:"colour,default:'blue'"`
+
+		// Check that no superficial migrations are generated for `autoincrement` columns.
+		BigInt   int64 `bun:",autoincrement"`
+		Int      int32 `bun:",autoincrement"`
+		SmallInt int16 `bun:",autoincrement"`
 	}
 
 	ctx := context.Background()
@@ -1090,7 +1095,6 @@ func testExcludeForeignKeys(t *testing.T, db *bun.DB) {
 
 	// Assert
 	state := inspect(ctx)
-
 	require.Contains(t, state.ForeignKeys, excluded,
 		"expected FK constraint things.owner_name -> owners.name")
 }

--- a/migrate/sqlschema/inspector.go
+++ b/migrate/sqlschema/inspector.go
@@ -113,6 +113,10 @@ type inspector struct {
 
 // BunModelInspector creates the current project state from the passed bun.Models.
 // Do not recycle BunModelInspector for different sets of models, as older models will not be de-registerred before the next run.
+//
+// BunModelInspector does not know which the database's dialect, so it does not
+// assume any default schema name. Always specify the target schema name via
+// WithSchemaName option to receive meaningful results.
 type BunModelInspector struct {
 	InspectorConfig
 	tables *schema.Tables
@@ -138,6 +142,7 @@ func (bmi *BunModelInspector) Inspect(ctx context.Context) (Database, error) {
 			if err != nil {
 				return nil, fmt.Errorf("parse length in %q: %w", f.CreateTableSQLType, err)
 			}
+
 			columns = append(columns, &BaseColumn{
 				Name:            f.Name,
 				SQLType:         strings.ToLower(sqlType), // TODO(dyma): maybe this is not necessary after Column.Eq()

--- a/schema/table.go
+++ b/schema/table.go
@@ -538,6 +538,7 @@ func (t *Table) newField(sf reflect.StructField, tag tagparser.Tag) *Field {
 	}
 	if tag.HasOption("autoincrement") {
 		field.AutoIncrement = true
+		field.NotNull = true
 		field.NullZero = true
 	}
 	if tag.HasOption("identity") {

--- a/schema/table_test.go
+++ b/schema/table_test.go
@@ -322,4 +322,17 @@ func TestTable(t *testing.T) {
 
 		require.Equal(t, table.FieldMap["foo"].SQLName, table.FieldMap["alt_name"].SQLName)
 	})
+
+	t.Run("autoincrement is not nullable", func(t *testing.T) {
+		type Thing struct {
+			Counter int `bun:",autoincrement"`
+		}
+
+		table := tables.Get(reflect.TypeFor[*Thing]())
+
+		require.Contains(t, table.FieldMap, "counter")
+		counter := table.FieldMap["counter"]
+		require.True(t, counter.AutoIncrement, "autoincrement")
+		require.True(t, counter.NotNull, "not null")
+	})
 }


### PR DESCRIPTION
Closes #1159 
Related #1166 

As per the related issue, AutoMigrator creates superficial migrations for `autoincrement` columns, attempting to change type to "SERIAL" (for Postgres) and drop NOT NULL.

Because SERIAL is a create-table alias for INTEGER + generated sequence, Postgres dialect should report the two types as equivalent. Exciting addition 🎉 : when changing a column type from INTEGER to SERIAL, the dialect will also add SQL to **create a backing sequence** first and **generate default value** from it. Previously we were not handling this case correctly.

Furthermore, fields with `autoincrement` tag should have `f.NotNull = true`, because an autoincremented field cannot contain null values. 