### PR TITLE
fix: sort foreign keys by name to ensure deterministic query

### DIFF
--- a/query_table_create.go
+++ b/query_table_create.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -308,8 +309,16 @@ func (q *CreateTableQuery) appendUniqueConstraint(
 
 // appendFKConstraintsRel appends a FOREIGN KEY clause for each of the model's existing relations.
 func (q *CreateTableQuery) appendFKConstraintsRel(fmter schema.Formatter, b []byte) (_ []byte, err error) {
-	for _, rel := range q.tableModel.Table().Relations {
-		if rel.References() {
+	relations := q.tableModel.Table().Relations
+
+	keys := make([]string, 0, len(relations))
+	for key := range relations {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	for _, key := range keys {
+		if rel := relations[key]; rel.References() {
 			b, err = q.appendFK(fmter, b, schema.QueryWithArgs{
 				Query: "(?) REFERENCES ? (?) ? ?",
 				Args: []interface{}{


### PR DESCRIPTION
This PR fixes https://github.com/uptrace/bun/issues/1205

This change introduces sorting for the foreign key constraints before they are appended to the query string.

The performance impact of sorting is expected to be negligible, as the number of foreign keys on a single table is typically small.
This approach is consistent with other parts of the codebase, [CreateTableQuery.appendUniqueConstraints](https://github.com/uptrace/bun/blob/a76da0dfa562bd6e3eb1b330de954c86f8e4daf7/query_table_create.go#L273-L279), which already sorts keys to ensure deterministic output. 