### PR TITLE
refactor: use slices package for sorting

### DIFF
--- a/model_map.go
+++ b/model_map.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"reflect"
-	"sort"
+	"slices"
 
 	"github.com/uptrace/bun/schema"
 )
@@ -121,7 +121,7 @@ func (m *mapModel) appendColumnsValues(fmter schema.Formatter, b []byte) []byte 
 	for k := range m.m {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 
 	b = append(b, " ("...)
 
@@ -157,7 +157,7 @@ func (m *mapModel) appendSet(fmter schema.Formatter, b []byte) []byte {
 	for k := range m.m {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 
 	isTemplate := fmter.IsNop()
 	for i, k := range keys {

--- a/model_map_slice.go
+++ b/model_map_slice.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"sort"
+	"slices"
 
 	"github.com/uptrace/bun/dialect/feature"
 	"github.com/uptrace/bun/schema"
@@ -155,7 +155,7 @@ func (m *mapSliceModel) initKeys() error {
 		keys = append(keys, k)
 	}
 
-	sort.Strings(keys)
+	slices.Sort(keys)
 	m.keys = keys
 
 	return nil

--- a/query_table_create.go
+++ b/query_table_create.go
@@ -6,7 +6,6 @@ import (
 	"database/sql"
 	"fmt"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -277,7 +276,7 @@ func (q *CreateTableQuery) appendUniqueConstraints(fmter schema.Formatter, b []b
 	for key := range unique {
 		keys = append(keys, key)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 
 	for _, key := range keys {
 		if key == "" {

--- a/schema/table.go
+++ b/schema/table.go
@@ -1,10 +1,11 @@
 package schema
 
 import (
+	"cmp"
 	"database/sql"
 	"fmt"
 	"reflect"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -299,15 +300,14 @@ func (t *Table) processFields(typ reflect.Type) {
 }
 
 func sortFieldsByStruct(fields []*Field) {
-	sort.Slice(fields, func(i, j int) bool {
-		left, right := fields[i], fields[j]
+	slices.SortFunc(fields, func(left, right *Field) int {
 		for k := 0; k < len(left.Index) && k < len(right.Index); k++ {
-			if left.Index[k] != right.Index[k] {
-				return left.Index[k] < right.Index[k]
+			if res := cmp.Compare(left.Index[k], right.Index[k]); res != 0 {
+				return res
 			}
 		}
 		// NOTE: should not reach
-		return true
+		return 0
 	})
 }
 


### PR DESCRIPTION
This PR migrates sorting logic from the legacy sort package to the modern slices package.

[Sorting for slices of struct values []migrate.Migration](https://github.com/uptrace/bun/blob/a76da0dfa562bd6e3eb1b330de954c86f8e4daf7/migrate/migration.go#L327-L337) has been intentionally excluded from this change, as slices.SortFunc copies the entire struct on each comparison.
Let me know if it's okay to ignore this concern.