### PR TITLE
feat(dialect): return default on update/delete when create table

### DIFF
--- a/dialect/feature/feature.go
+++ b/dialect/feature/feature.go
@@ -41,6 +41,7 @@ const (
 	DeleteOrderLimit // DELETE ... ORDER BY ... LIMIT ...
 	DeleteReturning
 	AlterColumnExists // ADD/DROP COLUMN IF NOT EXISTS/IF EXISTS
+	FKDefaultOnAction // FK ON UPDATE/ON DELETE has default value: NO ACTION
 )
 
 type NotSupportError struct {
@@ -91,4 +92,5 @@ var flag2str = map[Feature]string{
 	DeleteOrderLimit:     "DeleteOrderLimit",
 	DeleteReturning:      "DeleteReturning",
 	AlterColumnExists:    "AlterColumnExists",
+	FKDefaultOnAction:    "FKDefaultOnAction",
 }

--- a/dialect/mssqldialect/dialect.go
+++ b/dialect/mssqldialect/dialect.go
@@ -49,6 +49,7 @@ func New(opts ...DialectOption) *Dialect {
 		feature.Identity |
 		feature.Output |
 		feature.OffsetFetch |
+		feature.FKDefaultOnAction |
 		feature.UpdateFromTable |
 		feature.MSSavepoint
 
@@ -158,15 +159,15 @@ func (d *Dialect) AppendString(b []byte, s string) []byte {
 	return d.BaseDialect.AppendString(b, s)
 }
 
-func (d *Dialect) DefaultVarcharLen() int {
-	return 255
-}
-
 func (d *Dialect) AppendSequence(b []byte, _ *schema.Table, _ *schema.Field) []byte {
 	return append(b, " IDENTITY"...)
 }
 
-func (d *Dialect) DefaultSchema() string {
+func (*Dialect) DefaultVarcharLen() int {
+	return 255
+}
+
+func (*Dialect) DefaultSchema() string {
 	return "dbo"
 }
 

--- a/dialect/mysqldialect/dialect.go
+++ b/dialect/mysqldialect/dialect.go
@@ -48,6 +48,7 @@ func New(opts ...DialectOption) *Dialect {
 		feature.InsertOnDuplicateKey |
 		feature.SelectExists |
 		feature.CompositeIn |
+		feature.FKDefaultOnAction |
 		feature.UpdateOrderLimit |
 		feature.DeleteOrderLimit
 

--- a/dialect/pgdialect/dialect.go
+++ b/dialect/pgdialect/dialect.go
@@ -55,6 +55,7 @@ func New(opts ...DialectOption) *Dialect {
 		feature.SelectExists |
 		feature.GeneratedIdentity |
 		feature.CompositeIn |
+		feature.FKDefaultOnAction |
 		feature.DeleteReturning |
 		feature.AlterColumnExists
 

--- a/dialect/sqlitedialect/dialect.go
+++ b/dialect/sqlitedialect/dialect.go
@@ -41,6 +41,7 @@ func New(opts ...DialectOption) *Dialect {
 		feature.SelectExists |
 		feature.AutoIncrement |
 		feature.CompositeIn |
+		feature.FKDefaultOnAction |
 		feature.DeleteReturning
 
 	for _, opt := range opts {
@@ -102,7 +103,7 @@ func (d *Dialect) AppendBytes(b []byte, bs []byte) []byte {
 	return b
 }
 
-func (d *Dialect) DefaultVarcharLen() int {
+func (*Dialect) DefaultVarcharLen() int {
 	return 0
 }
 
@@ -132,7 +133,7 @@ func (d *Dialect) AppendSequence(b []byte, table *schema.Table, field *schema.Fi
 // DefaultSchemaName is the "schema-name" of the main database.
 // The details might differ from other dialects, but for all means and purposes
 // "main" is the default schema in an SQLite database.
-func (d *Dialect) DefaultSchema() string {
+func (*Dialect) DefaultSchema() string {
 	return "main"
 }
 

--- a/schema/table.go
+++ b/schema/table.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/jinzhu/inflection"
 
+	"github.com/uptrace/bun/dialect/feature"
 	"github.com/uptrace/bun/internal"
 	"github.com/uptrace/bun/internal/tagparser"
 )
@@ -623,7 +624,10 @@ func (t *Table) belongsToRelation(field *Field) *Relation {
 		rel.Condition = field.Tag.Options["join_on"]
 	}
 
-	rel.OnUpdate = "ON UPDATE NO ACTION"
+	if t.dialect.Features().Has(feature.FKDefaultOnAction) {
+		rel.OnUpdate = "ON UPDATE NO ACTION"
+		rel.OnDelete = "ON DELETE NO ACTION"
+	}
 	if onUpdate, ok := field.Tag.Options["on_update"]; ok {
 		if len(onUpdate) > 1 {
 			panic(fmt.Errorf("bun: %s belongs-to %s: on_update option must be a single field", t.TypeName, field.GoName))
@@ -638,7 +642,6 @@ func (t *Table) belongsToRelation(field *Field) *Relation {
 		rel.OnUpdate = s
 	}
 
-	rel.OnDelete = "ON DELETE NO ACTION"
 	if onDelete, ok := field.Tag.Options["on_delete"]; ok {
 		if len(onDelete) > 1 {
 			panic(fmt.Errorf("bun: %s belongs-to %s: on_delete option must be a single field", t.TypeName, field.GoName))


### PR DESCRIPTION
Oracle does not support ON UPDATE, but when WithForeignKeys is enabled, Bun unconditionally adds ON UPDATE/ON DELETE during table creation, which causes SQL errors.

The root cause of this issue is that different dialects have different rules for foreign keys, but Bun does not account for this. Instead, it uniformly adds ON UPDATE NO ACTION and ON DELETE NO ACTION as default values.

To resolve this, we need to delegate the default values of ON UPDATE/ON DELETE to the dialect, so each one can handle it appropriately.

Since SQLite, MSSQL, MySQL, and PostgreSQL all support ON UPDATE/ON DELETE with NO ACTION as the default, the only dialect that actually requires changes is Oracle.