### PR TITLE
fix: put spaces before negative numbers following minus signs in format.go to resolve CVE-2024-34359

### DIFF
--- a/driver/pgdriver/format.go
+++ b/driver/pgdriver/format.go
@@ -66,6 +66,11 @@ func appendArg(b []byte, v interface{}) ([]byte, error) {
 	case nil:
 		return append(b, "NULL"...), nil
 	case int64:
+		// To avoid accidental comments which can lead to SQL injection, put a space before
+		// negative numbers immediately following a minus sign.
+		if v < 0 && len(b) > 0 && b[len(b)-1] == '-' {
+			b = append(b, ' ')
+		}
 		return strconv.AppendInt(b, v, 10), nil
 	case float64:
 		switch {
@@ -76,6 +81,11 @@ func appendArg(b []byte, v interface{}) ([]byte, error) {
 		case math.IsInf(v, -1):
 			return append(b, "'-Infinity'"...), nil
 		default:
+			// To avoid accidental comments which can lead to SQL injection, put a space before
+			// negative numbers immediately following a minus sign.
+			if v < 0 && len(b) > 0 && b[len(b)-1] == '-' {
+				b = append(b, ' ')
+			}
 			return strconv.AppendFloat(b, v, 'f', -1, 64), nil
 		}
 	case bool:

--- a/driver/pgdriver/format_test.go
+++ b/driver/pgdriver/format_test.go
@@ -35,6 +35,29 @@ func TestFormatQuery(t *testing.T) {
 			args:   []interface{}{nil, "", []byte(nil), time.Time{}},
 			wanted: "select NULL,'',NULL,NULL",
 		},
+		{
+			query:  "select 1-$1, 1.0-$2, 1.0-$3",
+			args:   []interface{}{int64(-1), float64(-1.5), math.Inf(-1)},
+			wanted: "select 1- -1, 1.0- -1.5, 1.0-'-Infinity'",
+		},
+		{
+			query:  "select 1+$1, 1.0+$2",
+			args:   []interface{}{int64(-1), float64(-1.5)},
+			wanted: "select 1+-1, 1.0+-1.5",
+		},
+		{
+			query: "select 1-$1, $2",
+			args:  []interface{}{int64(-1), "foo\n;\nSELECT * FROM passwords;--"},
+			// Without a space before the negative number, the first line ends in a comment
+			wanted: `select 1- -1, 'foo
+;
+SELECT * FROM passwords;--'`,
+		},
+		{
+			query:  "$1",
+			args:   []interface{}{int64(-1)},
+			wanted: "-1",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
put spaces before negative numbers following minus signs in `format.go` to resolve CVE-2024-34359