### PR TITLE
chore(breaking): rename Listener.Channel to Listener.CreateChannel

### DIFF
--- a/driver/pgdriver/listener.go
+++ b/driver/pgdriver/listener.go
@@ -196,13 +196,13 @@ func (ln *Listener) unlisten(ctx context.Context, cn *Conn, channels ...string) 
 }
 
 // Receive indefinitely waits for a notification. This is low-level API
-// and in most cases Channel should be used instead.
+// and in most cases CreateChannel should be used instead.
 func (ln *Listener) Receive(ctx context.Context) (channel string, payload string, err error) {
 	return ln.ReceiveTimeout(ctx, 0)
 }
 
 // ReceiveTimeout waits for a notification until timeout is reached.
-// This is low-level API and in most cases Channel should be used instead.
+// This is low-level API and in most cases CreateChannel should be used instead.
 func (ln *Listener) ReceiveTimeout(
 	ctx context.Context, timeout time.Duration,
 ) (channel, payload string, err error) {
@@ -226,12 +226,12 @@ func (ln *Listener) ReceiveTimeout(
 	return channel, payload, nil
 }
 
-// Channel returns a channel for concurrently receiving notifications.
+// CreateChannel creates and returns a channel for concurrently receiving notifications.
 // It periodically sends Ping notification to test connection health.
 //
 // The channel is closed with Listener. Receive* APIs can not be used
 // after channel is created.
-func (ln *Listener) Channel(opts ...ChannelOption) <-chan Notification {
+func (ln *Listener) CreateChannel(opts ...ChannelOption) <-chan Notification {
 	return newChannel(ln, opts).ch
 }
 

--- a/example/pg-listen/main.go
+++ b/example/pg-listen/main.go
@@ -38,7 +38,7 @@ func main() {
 		panic(err)
 	}
 
-	for notif := range ln.Channel() {
+	for notif := range ln.CreateChannel() {
 		fmt.Println(notif.Channel, notif.Payload)
 	}
 }

--- a/internal/dbtest/listener_test.go
+++ b/internal/dbtest/listener_test.go
@@ -58,7 +58,7 @@ func TestListenerChannel(t *testing.T) {
 	db := pg(t)
 
 	ln := pgdriver.NewListener(db)
-	ch := ln.Channel()
+	ch := ln.CreateChannel()
 
 	err := ln.Listen(ctx, "test_channel")
 	require.NoError(t, err)
@@ -101,7 +101,7 @@ func TestListenerChannelOverflowHandler(t *testing.T) {
 	var overflowCount atomic.Int32
 
 	// Create channel with small buffer and overflow handler
-	ch := ln.Channel(
+	ch := ln.CreateChannel(
 		pgdriver.WithChannelSize(channelSize),
 		pgdriver.WithChannelOverflowHandler(func(n pgdriver.Notification) {
 			overflowCount.Add(1)


### PR DESCRIPTION
*pgdriver.Listener.Channel is not a Getter.
It`s a method that creates wrapped channel and returns channel of it.

More details [HERE](https://github.com/uptrace/bun/discussions/594#discussioncomment-13611029)

p.s. if major changes can't be accepted, i suggest to add godoc at least.