### PR TITLE
feat: Now scanBool, scanInt64 and scanUint64 are compatible with int8/int16/int64 to adapt to some database drivers

### DIFF
--- a/schema/scan.go
+++ b/schema/scan.go
@@ -137,7 +137,16 @@ func scanBool(dest reflect.Value, src interface{}) error {
 	case bool:
 		dest.SetBool(src)
 		return nil
-	case int8, int16, int32, int64:
+	case int8:
+		dest.SetBool(src != 0)
+		return nil
+	case int16:
+		dest.SetBool(src != 0)
+		return nil
+	case int32:
+		dest.SetBool(src != 0)
+		return nil
+	case int64:
 		dest.SetBool(src != 0)
 		return nil
 	case []byte:

--- a/schema/scan.go
+++ b/schema/scan.go
@@ -137,7 +137,7 @@ func scanBool(dest reflect.Value, src interface{}) error {
 	case bool:
 		dest.SetBool(src)
 		return nil
-	case int64:
+	case int8, int16, int32, int64:
 		dest.SetBool(src != 0)
 		return nil
 	case []byte:
@@ -164,8 +164,26 @@ func scanInt64(dest reflect.Value, src interface{}) error {
 	case nil:
 		dest.SetInt(0)
 		return nil
+	case int8:
+		dest.SetInt(int64(src))
+		return nil
+	case int16:
+		dest.SetInt(int64(src))
+		return nil
+	case int32:
+		dest.SetInt(int64(src))
+		return nil
 	case int64:
 		dest.SetInt(src)
+		return nil
+	case uint8:
+		dest.SetInt(int64(src))
+		return nil
+	case uint16:
+		dest.SetInt(int64(src))
+		return nil
+	case uint32:
+		dest.SetInt(int64(src))
 		return nil
 	case uint64:
 		dest.SetInt(int64(src))
@@ -194,8 +212,26 @@ func scanUint64(dest reflect.Value, src interface{}) error {
 	case nil:
 		dest.SetUint(0)
 		return nil
+	case uint8:
+		dest.SetUint(uint64(src))
+		return nil
+	case uint16:
+		dest.SetUint(uint64(src))
+		return nil
+	case uint32:
+		dest.SetUint(uint64(src))
+		return nil
 	case uint64:
 		dest.SetUint(src)
+		return nil
+	case int8:
+		dest.SetUint(uint64(src))
+		return nil
+	case int16:
+		dest.SetUint(uint64(src))
+		return nil
+	case int32:
+		dest.SetUint(uint64(src))
 		return nil
 	case int64:
 		dest.SetUint(uint64(src))


### PR DESCRIPTION
The driver provided by the database I am currently using returns a scanError when performing Scan in the bun framework. When the golang type is defined as int8, the returned error is similar to "bun: can't scan hidden(int8) into int8", after debugging, the problem occurs in several functions such as scanInt8 and scanInt16 defined in schema.scanners specified as scanInt64, when the current database driver reaches this point, src is int8, and in scanInt64, when asserting src, only int64 is matched. The same applies to scanUint64 and scanBool. Now, to solve this problem, I have forked a repository In addition, for the three functions scanInt64, scanUint64, and scanBool, matching for int8, int16, int32, etc. has been added. Currently, the program is running normally. I wonder if there will be any other issues with this modification. Also, will the main repository accept this modification?