### PR TITLE
fix: revert CreateChannel rename

### DIFF
--- a/example/pg-listen/main.go
+++ b/example/pg-listen/main.go
@@ -38,7 +38,7 @@ func main() {
 		panic(err)
 	}
 
-	for notif := range ln.CreateChannel() {
+	for notif := range ln.Channel() {
 		fmt.Println(notif.Channel, notif.Payload)
 	}
 }

--- a/internal/dbtest/listener_test.go
+++ b/internal/dbtest/listener_test.go
@@ -58,7 +58,7 @@ func TestListenerChannel(t *testing.T) {
 	db := pg(t)
 
 	ln := pgdriver.NewListener(db)
-	ch := ln.CreateChannel()
+	ch := ln.Channel()
 
 	err := ln.Listen(ctx, "test_channel")
 	require.NoError(t, err)
@@ -101,7 +101,7 @@ func TestListenerChannelOverflowHandler(t *testing.T) {
 	var overflowCount atomic.Int32
 
 	// Create channel with small buffer and overflow handler
-	ch := ln.CreateChannel(
+	ch := ln.Channel(
 		pgdriver.WithChannelSize(channelSize),
 		pgdriver.WithChannelOverflowHandler(func(n pgdriver.Notification) {
 			overflowCount.Add(1)


### PR DESCRIPTION
The name CreateChannel suggests that you can call it multiple times to create several channels, but it won't work because listener is not concurrently safe.