### PR TITLE
fix: sql injection #1228

### DIFF
--- a/driver/pgdriver/driver.go
+++ b/driver/pgdriver/driver.go
@@ -137,6 +137,13 @@ func newConn(ctx context.Context, conf *Config) (*Conn, error) {
 	}
 
 	for k, v := range conf.ConnParams {
+		switch {
+		case k == "standard_conforming_strings" && (v != nil && v != "on"):
+			return nil, errRequiresParameter
+		case k == "client_encoding" && (v != nil && v != "UTF8"):
+			return nil, errRequiresParameter
+		}
+
 		if v != nil {
 			_, err = cn.ExecContext(ctx, fmt.Sprintf("SET %s TO $1", k), []driver.NamedValue{
 				{Value: v},

--- a/driver/pgdriver/error.go
+++ b/driver/pgdriver/error.go
@@ -2,6 +2,7 @@ package pgdriver
 
 import (
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"net"
 )
@@ -73,3 +74,7 @@ func isBadConn(err error, allowTimeout bool) bool {
 
 	return true
 }
+
+var (
+	errRequiresParameter = errors.New("pgdriver: requires that standard_conforming_strings=on and client_encoding=UTF8")
+)


### PR DESCRIPTION
The pgdriver requires that standard_conforming_strings=on and client_encoding=UTF8. Enforce this requirement to prevent SQL injection vulnerabilities.