### PR TITLE
fix(m2m): remap BasePKs to the owner model table for bun:",extend" support

### DIFF
--- a/model_table_m2m.go
+++ b/model_table_m2m.go
@@ -22,9 +22,11 @@ type m2mModel struct {
 var _ TableModel = (*m2mModel)(nil)
 
 func newM2MModel(j *relationJoin) *m2mModel {
-	baseTable := j.BaseModel.Table()
-	joinModel := j.JoinModel.(*sliceTableModel)
-	baseValues := baseValues(joinModel, j.Relation.BasePKs)
+    baseTable := j.BaseModel.Table()
+    joinModel := j.JoinModel.(*sliceTableModel)
+    // Remap BasePKs to the owner (base) model table to account for bun:",extend".
+    remappedBasePKs := remapFieldsToTable(j.Relation.BasePKs, j.BaseModel.Table())
+    baseValues := baseValues(joinModel, remappedBasePKs)
 	if len(baseValues) == 0 {
 		return nil
 	}


### PR DESCRIPTION
## Summary

This PR fixes a panic and join-result parking mismatch when loading many-to-many relations from a struct that embeds another model via bun:",extend". The issue was reported upstream (uptrace/bun#1237).
The fix ensures primary key values are collected from the correct owner struct when “extend” flattens fields, and that result parking keys align with the base model.

## Root Cause

- With bun:",extend", the relation metadata (BasePKs) comes from the embedded type. During m2m relation loading:
    - The join builder collected IN (...) values by mixing a root value from one model with field indices intended for another. Under extend, this can point at the wrong field type, causing reflect
panics.
    - The result “parking” keyed base models using BasePK field indices that didn’t match the owner struct under extend, causing “does not have base model with key …” errors.

## Changes

- relation_join.go:
    - Remap BasePK fields to the base model’s table before collecting values.
    - Use the join model’s view (root + parent index) consistently when appending IN (...) values.
- model_table_m2m.go:
    - Remap BasePK fields to the base model’s table before computing baseValues map keys for parking.
- util.go:
    - Add helper remapFieldsToTable to safely map fields by SQL name into the owner table. Keeps logic DRY and avoids mutating cached schema structures.
- Tests:
    - internal/dbtest/orm_test.go: Add testM2MWithExtend using existing Book/Genre/BookGenre and BookWithCommentCount (bun:",extend") to assert Relation("Genres") works.
    - internal/dbtest/extend_m2m_issue1237_test.go: Minimal regression repro that exercises extend+m2m via existing models and asserts no error.
    - Removed ad‑hoc standalone tests to keep suite focused on existing models.
