### PR TITLE
fix: return "custom" for unknown dialects instead of "invalid"

### DIFF
--- a/dialect/dialect.go
+++ b/dialect/dialect.go
@@ -4,6 +4,8 @@ type Name int
 
 func (n Name) String() string {
 	switch n {
+	case Invalid:
+		return "invalid"
 	case PG:
 		return "pg"
 	case SQLite:
@@ -15,7 +17,7 @@ func (n Name) String() string {
 	case Oracle:
 		return "oracle"
 	default:
-		return "invalid"
+		return "custom"
 	}
 }
 


### PR DESCRIPTION
Previously, the Name.String() method returned "invalid" for all unknown dialects, which was semantically incorrect for custom dialects. This change distinguishes between truly invalid (uninitialized) dialects and custom (unknown but valid) dialects.

Changes:
- Add explicit case for Invalid dialect to return "invalid"
- Change default case to return "custom" for unknown dialects
- Improves framework extensibility for custom dialect implementations

Fixes #1276