### PR TITLE
fix: Rare panic in indirectAsKey (model_table_has_many.go) when loading complex models

### DIFF
--- a/model_table_has_many.go
+++ b/model_table_has_many.go
@@ -168,7 +168,7 @@ func indirectAsKey(field reflect.Value) any {
 
 	i := field.Interface()
 	if valuer, ok := i.(driver.Valuer); ok {
-		if v, err := valuer.Value(); err == nil {
+		if v, err := valuer.Value(); err == nil && v != nil {
 			switch reflect.TypeOf(v).Kind() {
 			case reflect.Array, reflect.Chan, reflect.Func,
 				reflect.Map, reflect.Pointer, reflect.Slice, reflect.UnsafePointer:


### PR DESCRIPTION
In model_table_has_many.go, the indirectAsKey method has a nil pointer bug. 
Calling reflect.TypeOf(v).Kind() if v is nil causes a panic.