### PR TITLE
fix: wrap WHERE conditions in parentheses when soft-delete AND WhereOr are combined

### DIFF
--- a/internal/dbtest/query_test.go
+++ b/internal/dbtest/query_test.go
@@ -1945,6 +1945,56 @@ func TestQuery(t *testing.T) {
 				}))
 			},
 		},
+		{
+			id: 205,
+			query: func(db *bun.DB) schema.QueryAppender {
+				return db.NewSelect().Model(new(SoftDelete1)).
+					Where("id = 1").
+					WhereOr("id = 2")
+			},
+		},
+		{
+			id: 206,
+			query: func(db *bun.DB) schema.QueryAppender {
+				return db.NewSelect().Model(new(SoftDelete1)).
+					WhereOr("id = 1").
+					WhereOr("id = 2")
+			},
+		},
+		{
+			id: 207,
+			query: func(db *bun.DB) schema.QueryAppender {
+				return db.NewSelect().Model(new(SoftDelete1)).
+					Where("id = 1").
+					WhereOr("id = 2").
+					WhereDeleted()
+			},
+		},
+		{
+			id: 208,
+			query: func(db *bun.DB) schema.QueryAppender {
+				return db.NewSelect().Model(new(SoftDelete1)).
+					Where("id = 1").
+					Where("id = 2")
+			},
+		},
+		{
+			id: 209,
+			query: func(db *bun.DB) schema.QueryAppender {
+				return db.NewDelete().Model(new(SoftDelete1)).
+					Where("id = 1").
+					WhereOr("id = 2")
+			},
+		},
+		{
+			id: 210,
+			query: func(db *bun.DB) schema.QueryAppender {
+				return db.NewUpdate().Model(new(SoftDelete1)).
+					Set("id = id").
+					Where("id = 1").
+					WhereOr("id = 2")
+			},
+		},
 	}
 
 	timeRE := regexp.MustCompile(`'2\d{3}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(\.\d+)?(\+\d{2}:\d{2})?'`)

--- a/internal/dbtest/query_test.go
+++ b/internal/dbtest/query_test.go
@@ -2024,18 +2024,44 @@ func TestSelectQueryClone(t *testing.T) {
 		DeletedAt time.Time `bun:",soft_delete,nullzero"`
 	}
 
+	tests := []struct {
+		name    string
+		build   func(*bun.SelectQuery) *bun.SelectQuery
+		pattern string
+	}{
+		{
+			name: "WhereOr",
+			build: func(q *bun.SelectQuery) *bun.SelectQuery {
+				return q.Where("id = 1").WhereOr("id = 2")
+			},
+			pattern: `WHERE \(\(id = 1\) OR \(id = 2\)\)`,
+		},
+		{
+			name: "WhereGroup or",
+			build: func(q *bun.SelectQuery) *bun.SelectQuery {
+				return q.Where("id = 1").WhereGroup(" or ", func(q *bun.SelectQuery) *bun.SelectQuery {
+					return q.Where("id = 2")
+				})
+			},
+			pattern: `WHERE \(\(id = 1\) or \(\(id = 2\)\)\)`,
+		},
+	}
+
 	testEachDB(t, func(t *testing.T, dbName string, db *bun.DB) {
-		q := db.NewSelect().Model(new(SoftDelete1)).
-			Where("id = 1").
-			WhereOr("id = 2")
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				q := tt.build(db.NewSelect().Model(new(SoftDelete1)))
 
-		original, err := q.AppendQuery(db.QueryGen(), nil)
-		require.NoError(t, err)
+				original, err := q.AppendQuery(db.QueryGen(), nil)
+				require.NoError(t, err)
 
-		clone, err := q.Clone().AppendQuery(db.QueryGen(), nil)
-		require.NoError(t, err)
+				clone, err := q.Clone().AppendQuery(db.QueryGen(), nil)
+				require.NoError(t, err)
 
-		require.Equal(t, string(original), string(clone))
+				require.Equal(t, string(original), string(clone))
+				require.Regexp(t, tt.pattern, string(clone))
+			})
+		}
 	})
 }
 

--- a/internal/dbtest/query_test.go
+++ b/internal/dbtest/query_test.go
@@ -2016,6 +2016,29 @@ func TestQuery(t *testing.T) {
 	})
 }
 
+func TestSelectQueryClone(t *testing.T) {
+	type SoftDelete1 struct {
+		bun.BaseModel `bun:"soft_deletes,alias:soft_delete"`
+
+		ID        int64     `bun:",pk,autoincrement"`
+		DeletedAt time.Time `bun:",soft_delete,nullzero"`
+	}
+
+	testEachDB(t, func(t *testing.T, dbName string, db *bun.DB) {
+		q := db.NewSelect().Model(new(SoftDelete1)).
+			Where("id = 1").
+			WhereOr("id = 2")
+
+		original, err := q.AppendQuery(db.QueryGen(), nil)
+		require.NoError(t, err)
+
+		clone, err := q.Clone().AppendQuery(db.QueryGen(), nil)
+		require.NoError(t, err)
+
+		require.Equal(t, string(original), string(clone))
+	})
+}
+
 func TestAlterTable(t *testing.T) {
 	type Movie struct {
 		bun.BaseModel `bun:"table:hobbies.movies"`

--- a/internal/dbtest/testdata/snapshots/TestQuery-mariadb-118
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mariadb-118
@@ -1,1 +1,1 @@
-UPDATE `soft_deletes` AS `soft_delete` SET `deleted_at` = DEFAULT WHERE ((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2)) AND `soft_delete`.`deleted_at` IS NULL AND (`soft_delete`.`id` = NULL)
+UPDATE `soft_deletes` AS `soft_delete` SET `deleted_at` = DEFAULT WHERE (((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2))) AND `soft_delete`.`deleted_at` IS NULL AND (`soft_delete`.`id` = NULL)

--- a/internal/dbtest/testdata/snapshots/TestQuery-mariadb-124
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mariadb-124
@@ -1,1 +1,1 @@
-UPDATE `soft_deletes` AS `soft_delete` SET `soft_delete`.`deleted_at` = [TIME] WHERE ((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2)) AND `soft_delete`.`deleted_at` IS NULL AND (`soft_delete`.`id` = NULL)
+UPDATE `soft_deletes` AS `soft_delete` SET `soft_delete`.`deleted_at` = [TIME] WHERE (((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2))) AND `soft_delete`.`deleted_at` IS NULL AND (`soft_delete`.`id` = NULL)

--- a/internal/dbtest/testdata/snapshots/TestQuery-mariadb-205
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mariadb-205
@@ -1,0 +1,1 @@
+SELECT `soft_delete`.`id`, `soft_delete`.`deleted_at` FROM `soft_deletes` AS `soft_delete` WHERE ((id = 1) OR (id = 2)) AND `soft_delete`.`deleted_at` IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-mariadb-206
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mariadb-206
@@ -1,0 +1,1 @@
+SELECT `soft_delete`.`id`, `soft_delete`.`deleted_at` FROM `soft_deletes` AS `soft_delete` WHERE ((id = 1) OR (id = 2)) AND `soft_delete`.`deleted_at` IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-mariadb-207
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mariadb-207
@@ -1,0 +1,1 @@
+SELECT `soft_delete`.`id`, `soft_delete`.`deleted_at` FROM `soft_deletes` AS `soft_delete` WHERE ((id = 1) OR (id = 2)) AND `soft_delete`.`deleted_at` IS NOT NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-mariadb-208
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mariadb-208
@@ -1,0 +1,1 @@
+SELECT `soft_delete`.`id`, `soft_delete`.`deleted_at` FROM `soft_deletes` AS `soft_delete` WHERE (id = 1) AND (id = 2) AND `soft_delete`.`deleted_at` IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-mariadb-209
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mariadb-209
@@ -1,0 +1,1 @@
+UPDATE `soft_deletes` AS `soft_delete` SET `soft_delete`.`deleted_at` = [TIME] WHERE ((id = 1) OR (id = 2)) AND `soft_delete`.`deleted_at` IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-mariadb-210
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mariadb-210
@@ -1,0 +1,1 @@
+UPDATE `soft_deletes` AS `soft_delete` SET id = id WHERE ((id = 1) OR (id = 2)) AND `soft_delete`.`deleted_at` IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-118
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-118
@@ -1,1 +1,1 @@
-UPDATE "soft_deletes" SET "deleted_at" = DEFAULT WHERE ((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2)) AND "soft_deletes"."deleted_at" IS NULL AND ("id" = NULL)
+UPDATE "soft_deletes" SET "deleted_at" = DEFAULT WHERE (((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2))) AND "soft_deletes"."deleted_at" IS NULL AND ("id" = NULL)

--- a/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-124
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-124
@@ -1,1 +1,1 @@
-UPDATE "soft_deletes" SET "deleted_at" = [TIME] WHERE ((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2)) AND "soft_deletes"."deleted_at" IS NULL AND ("id" = NULL)
+UPDATE "soft_deletes" SET "deleted_at" = [TIME] WHERE (((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2))) AND "soft_deletes"."deleted_at" IS NULL AND ("id" = NULL)

--- a/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-205
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-205
@@ -1,0 +1,1 @@
+SELECT "soft_delete"."id", "soft_delete"."deleted_at" FROM "soft_deletes" AS "soft_delete" WHERE ((id = 1) OR (id = 2)) AND "soft_delete"."deleted_at" IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-206
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-206
@@ -1,0 +1,1 @@
+SELECT "soft_delete"."id", "soft_delete"."deleted_at" FROM "soft_deletes" AS "soft_delete" WHERE ((id = 1) OR (id = 2)) AND "soft_delete"."deleted_at" IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-207
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-207
@@ -1,0 +1,1 @@
+SELECT "soft_delete"."id", "soft_delete"."deleted_at" FROM "soft_deletes" AS "soft_delete" WHERE ((id = 1) OR (id = 2)) AND "soft_delete"."deleted_at" IS NOT NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-208
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-208
@@ -1,0 +1,1 @@
+SELECT "soft_delete"."id", "soft_delete"."deleted_at" FROM "soft_deletes" AS "soft_delete" WHERE (id = 1) AND (id = 2) AND "soft_delete"."deleted_at" IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-209
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-209
@@ -1,0 +1,1 @@
+UPDATE "soft_deletes" SET "deleted_at" = [TIME] WHERE ((id = 1) OR (id = 2)) AND "soft_deletes"."deleted_at" IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-210
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-210
@@ -1,0 +1,1 @@
+UPDATE "soft_deletes" SET id = id WHERE ((id = 1) OR (id = 2)) AND "soft_deletes"."deleted_at" IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql5-118
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql5-118
@@ -1,1 +1,1 @@
-UPDATE `soft_deletes` AS `soft_delete` SET `deleted_at` = DEFAULT WHERE ((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2)) AND `soft_delete`.`deleted_at` IS NULL AND (`soft_delete`.`id` = NULL)
+UPDATE `soft_deletes` AS `soft_delete` SET `deleted_at` = DEFAULT WHERE (((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2))) AND `soft_delete`.`deleted_at` IS NULL AND (`soft_delete`.`id` = NULL)

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql5-124
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql5-124
@@ -1,1 +1,1 @@
-UPDATE `soft_deletes` AS `soft_delete` SET `soft_delete`.`deleted_at` = [TIME] WHERE ((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2)) AND `soft_delete`.`deleted_at` IS NULL AND (`soft_delete`.`id` = NULL)
+UPDATE `soft_deletes` AS `soft_delete` SET `soft_delete`.`deleted_at` = [TIME] WHERE (((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2))) AND `soft_delete`.`deleted_at` IS NULL AND (`soft_delete`.`id` = NULL)

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql5-205
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql5-205
@@ -1,0 +1,1 @@
+SELECT `soft_delete`.`id`, `soft_delete`.`deleted_at` FROM `soft_deletes` AS `soft_delete` WHERE ((id = 1) OR (id = 2)) AND `soft_delete`.`deleted_at` IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql5-206
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql5-206
@@ -1,0 +1,1 @@
+SELECT `soft_delete`.`id`, `soft_delete`.`deleted_at` FROM `soft_deletes` AS `soft_delete` WHERE ((id = 1) OR (id = 2)) AND `soft_delete`.`deleted_at` IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql5-207
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql5-207
@@ -1,0 +1,1 @@
+SELECT `soft_delete`.`id`, `soft_delete`.`deleted_at` FROM `soft_deletes` AS `soft_delete` WHERE ((id = 1) OR (id = 2)) AND `soft_delete`.`deleted_at` IS NOT NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql5-208
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql5-208
@@ -1,0 +1,1 @@
+SELECT `soft_delete`.`id`, `soft_delete`.`deleted_at` FROM `soft_deletes` AS `soft_delete` WHERE (id = 1) AND (id = 2) AND `soft_delete`.`deleted_at` IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql5-209
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql5-209
@@ -1,0 +1,1 @@
+UPDATE `soft_deletes` AS `soft_delete` SET `soft_delete`.`deleted_at` = [TIME] WHERE ((id = 1) OR (id = 2)) AND `soft_delete`.`deleted_at` IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql5-210
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql5-210
@@ -1,0 +1,1 @@
+UPDATE `soft_deletes` AS `soft_delete` SET id = id WHERE ((id = 1) OR (id = 2)) AND `soft_delete`.`deleted_at` IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql8-118
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql8-118
@@ -1,1 +1,1 @@
-UPDATE `soft_deletes` AS `soft_delete` SET `deleted_at` = DEFAULT WHERE ((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2)) AND `soft_delete`.`deleted_at` IS NULL AND (`soft_delete`.`id` = NULL)
+UPDATE `soft_deletes` AS `soft_delete` SET `deleted_at` = DEFAULT WHERE (((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2))) AND `soft_delete`.`deleted_at` IS NULL AND (`soft_delete`.`id` = NULL)

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql8-124
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql8-124
@@ -1,1 +1,1 @@
-UPDATE `soft_deletes` AS `soft_delete` SET `soft_delete`.`deleted_at` = [TIME] WHERE ((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2)) AND `soft_delete`.`deleted_at` IS NULL AND (`soft_delete`.`id` = NULL)
+UPDATE `soft_deletes` AS `soft_delete` SET `soft_delete`.`deleted_at` = [TIME] WHERE (((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2))) AND `soft_delete`.`deleted_at` IS NULL AND (`soft_delete`.`id` = NULL)

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql8-205
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql8-205
@@ -1,0 +1,1 @@
+SELECT `soft_delete`.`id`, `soft_delete`.`deleted_at` FROM `soft_deletes` AS `soft_delete` WHERE ((id = 1) OR (id = 2)) AND `soft_delete`.`deleted_at` IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql8-206
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql8-206
@@ -1,0 +1,1 @@
+SELECT `soft_delete`.`id`, `soft_delete`.`deleted_at` FROM `soft_deletes` AS `soft_delete` WHERE ((id = 1) OR (id = 2)) AND `soft_delete`.`deleted_at` IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql8-207
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql8-207
@@ -1,0 +1,1 @@
+SELECT `soft_delete`.`id`, `soft_delete`.`deleted_at` FROM `soft_deletes` AS `soft_delete` WHERE ((id = 1) OR (id = 2)) AND `soft_delete`.`deleted_at` IS NOT NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql8-208
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql8-208
@@ -1,0 +1,1 @@
+SELECT `soft_delete`.`id`, `soft_delete`.`deleted_at` FROM `soft_deletes` AS `soft_delete` WHERE (id = 1) AND (id = 2) AND `soft_delete`.`deleted_at` IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql8-209
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql8-209
@@ -1,0 +1,1 @@
+UPDATE `soft_deletes` AS `soft_delete` SET `soft_delete`.`deleted_at` = [TIME] WHERE ((id = 1) OR (id = 2)) AND `soft_delete`.`deleted_at` IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql8-210
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql8-210
@@ -1,0 +1,1 @@
+UPDATE `soft_deletes` AS `soft_delete` SET id = id WHERE ((id = 1) OR (id = 2)) AND `soft_delete`.`deleted_at` IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-pg-118
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pg-118
@@ -1,1 +1,1 @@
-UPDATE "soft_deletes" AS "soft_delete" SET "deleted_at" = DEFAULT WHERE ((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2)) AND "soft_delete"."deleted_at" IS NULL AND ("soft_delete"."id" = NULL)
+UPDATE "soft_deletes" AS "soft_delete" SET "deleted_at" = DEFAULT WHERE (((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2))) AND "soft_delete"."deleted_at" IS NULL AND ("soft_delete"."id" = NULL)

--- a/internal/dbtest/testdata/snapshots/TestQuery-pg-124
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pg-124
@@ -1,1 +1,1 @@
-UPDATE "soft_deletes" AS "soft_delete" SET "deleted_at" = [TIME] WHERE ((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2)) AND "soft_delete"."deleted_at" IS NULL AND ("soft_delete"."id" = NULL)
+UPDATE "soft_deletes" AS "soft_delete" SET "deleted_at" = [TIME] WHERE (((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2))) AND "soft_delete"."deleted_at" IS NULL AND ("soft_delete"."id" = NULL)

--- a/internal/dbtest/testdata/snapshots/TestQuery-pg-205
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pg-205
@@ -1,0 +1,1 @@
+SELECT "soft_delete"."id", "soft_delete"."deleted_at" FROM "soft_deletes" AS "soft_delete" WHERE ((id = 1) OR (id = 2)) AND "soft_delete"."deleted_at" IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-pg-206
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pg-206
@@ -1,0 +1,1 @@
+SELECT "soft_delete"."id", "soft_delete"."deleted_at" FROM "soft_deletes" AS "soft_delete" WHERE ((id = 1) OR (id = 2)) AND "soft_delete"."deleted_at" IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-pg-207
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pg-207
@@ -1,0 +1,1 @@
+SELECT "soft_delete"."id", "soft_delete"."deleted_at" FROM "soft_deletes" AS "soft_delete" WHERE ((id = 1) OR (id = 2)) AND "soft_delete"."deleted_at" IS NOT NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-pg-208
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pg-208
@@ -1,0 +1,1 @@
+SELECT "soft_delete"."id", "soft_delete"."deleted_at" FROM "soft_deletes" AS "soft_delete" WHERE (id = 1) AND (id = 2) AND "soft_delete"."deleted_at" IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-pg-209
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pg-209
@@ -1,0 +1,1 @@
+UPDATE "soft_deletes" AS "soft_delete" SET "deleted_at" = [TIME] WHERE ((id = 1) OR (id = 2)) AND "soft_delete"."deleted_at" IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-pg-210
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pg-210
@@ -1,0 +1,1 @@
+UPDATE "soft_deletes" AS "soft_delete" SET id = id WHERE ((id = 1) OR (id = 2)) AND "soft_delete"."deleted_at" IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-pgx-118
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pgx-118
@@ -1,1 +1,1 @@
-UPDATE "soft_deletes" AS "soft_delete" SET "deleted_at" = DEFAULT WHERE ((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2)) AND "soft_delete"."deleted_at" IS NULL AND ("soft_delete"."id" = NULL)
+UPDATE "soft_deletes" AS "soft_delete" SET "deleted_at" = DEFAULT WHERE (((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2))) AND "soft_delete"."deleted_at" IS NULL AND ("soft_delete"."id" = NULL)

--- a/internal/dbtest/testdata/snapshots/TestQuery-pgx-124
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pgx-124
@@ -1,1 +1,1 @@
-UPDATE "soft_deletes" AS "soft_delete" SET "deleted_at" = [TIME] WHERE ((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2)) AND "soft_delete"."deleted_at" IS NULL AND ("soft_delete"."id" = NULL)
+UPDATE "soft_deletes" AS "soft_delete" SET "deleted_at" = [TIME] WHERE (((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2))) AND "soft_delete"."deleted_at" IS NULL AND ("soft_delete"."id" = NULL)

--- a/internal/dbtest/testdata/snapshots/TestQuery-pgx-205
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pgx-205
@@ -1,0 +1,1 @@
+SELECT "soft_delete"."id", "soft_delete"."deleted_at" FROM "soft_deletes" AS "soft_delete" WHERE ((id = 1) OR (id = 2)) AND "soft_delete"."deleted_at" IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-pgx-206
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pgx-206
@@ -1,0 +1,1 @@
+SELECT "soft_delete"."id", "soft_delete"."deleted_at" FROM "soft_deletes" AS "soft_delete" WHERE ((id = 1) OR (id = 2)) AND "soft_delete"."deleted_at" IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-pgx-207
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pgx-207
@@ -1,0 +1,1 @@
+SELECT "soft_delete"."id", "soft_delete"."deleted_at" FROM "soft_deletes" AS "soft_delete" WHERE ((id = 1) OR (id = 2)) AND "soft_delete"."deleted_at" IS NOT NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-pgx-208
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pgx-208
@@ -1,0 +1,1 @@
+SELECT "soft_delete"."id", "soft_delete"."deleted_at" FROM "soft_deletes" AS "soft_delete" WHERE (id = 1) AND (id = 2) AND "soft_delete"."deleted_at" IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-pgx-209
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pgx-209
@@ -1,0 +1,1 @@
+UPDATE "soft_deletes" AS "soft_delete" SET "deleted_at" = [TIME] WHERE ((id = 1) OR (id = 2)) AND "soft_delete"."deleted_at" IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-pgx-210
+++ b/internal/dbtest/testdata/snapshots/TestQuery-pgx-210
@@ -1,0 +1,1 @@
+UPDATE "soft_deletes" AS "soft_delete" SET id = id WHERE ((id = 1) OR (id = 2)) AND "soft_delete"."deleted_at" IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-sqlite-118
+++ b/internal/dbtest/testdata/snapshots/TestQuery-sqlite-118
@@ -1,1 +1,1 @@
-UPDATE "soft_deletes" AS "soft_delete" SET "deleted_at" = NULL WHERE ((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2)) AND "soft_delete"."deleted_at" IS NULL AND ("soft_delete"."id" = NULL)
+UPDATE "soft_deletes" AS "soft_delete" SET "deleted_at" = NULL WHERE (((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2))) AND "soft_delete"."deleted_at" IS NULL AND ("soft_delete"."id" = NULL)

--- a/internal/dbtest/testdata/snapshots/TestQuery-sqlite-124
+++ b/internal/dbtest/testdata/snapshots/TestQuery-sqlite-124
@@ -1,1 +1,1 @@
-UPDATE "soft_deletes" AS "soft_delete" SET "deleted_at" = [TIME] WHERE ((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2)) AND "soft_delete"."deleted_at" IS NULL AND ("soft_delete"."id" = NULL)
+UPDATE "soft_deletes" AS "soft_delete" SET "deleted_at" = [TIME] WHERE (((a = 1) AND (b = 1)) OR ((a = 2) AND (b = 2))) AND "soft_delete"."deleted_at" IS NULL AND ("soft_delete"."id" = NULL)

--- a/internal/dbtest/testdata/snapshots/TestQuery-sqlite-205
+++ b/internal/dbtest/testdata/snapshots/TestQuery-sqlite-205
@@ -1,0 +1,1 @@
+SELECT "soft_delete"."id", "soft_delete"."deleted_at" FROM "soft_deletes" AS "soft_delete" WHERE ((id = 1) OR (id = 2)) AND "soft_delete"."deleted_at" IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-sqlite-206
+++ b/internal/dbtest/testdata/snapshots/TestQuery-sqlite-206
@@ -1,0 +1,1 @@
+SELECT "soft_delete"."id", "soft_delete"."deleted_at" FROM "soft_deletes" AS "soft_delete" WHERE ((id = 1) OR (id = 2)) AND "soft_delete"."deleted_at" IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-sqlite-207
+++ b/internal/dbtest/testdata/snapshots/TestQuery-sqlite-207
@@ -1,0 +1,1 @@
+SELECT "soft_delete"."id", "soft_delete"."deleted_at" FROM "soft_deletes" AS "soft_delete" WHERE ((id = 1) OR (id = 2)) AND "soft_delete"."deleted_at" IS NOT NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-sqlite-208
+++ b/internal/dbtest/testdata/snapshots/TestQuery-sqlite-208
@@ -1,0 +1,1 @@
+SELECT "soft_delete"."id", "soft_delete"."deleted_at" FROM "soft_deletes" AS "soft_delete" WHERE (id = 1) AND (id = 2) AND "soft_delete"."deleted_at" IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-sqlite-209
+++ b/internal/dbtest/testdata/snapshots/TestQuery-sqlite-209
@@ -1,0 +1,1 @@
+UPDATE "soft_deletes" AS "soft_delete" SET "deleted_at" = [TIME] WHERE ((id = 1) OR (id = 2)) AND "soft_delete"."deleted_at" IS NULL

--- a/internal/dbtest/testdata/snapshots/TestQuery-sqlite-210
+++ b/internal/dbtest/testdata/snapshots/TestQuery-sqlite-210
@@ -1,0 +1,1 @@
+UPDATE "soft_deletes" AS "soft_delete" SET id = id WHERE ((id = 1) OR (id = 2)) AND "soft_delete"."deleted_at" IS NULL

--- a/query_base.go
+++ b/query_base.go
@@ -772,9 +772,13 @@ type whereBaseQuery struct {
 
 	where       []schema.QueryWithSep
 	whereFields []*schema.Field
+	whereHasOr  bool
 }
 
 func (q *whereBaseQuery) addWhere(where schema.QueryWithSep) {
+	if strings.Contains(where.Sep, "OR") {
+		q.whereHasOr = true
+	}
 	q.where = append(q.where, where)
 }
 
@@ -844,10 +848,18 @@ func (q *whereBaseQuery) appendWhere(
 	b = append(b, " WHERE "...)
 	startLen := len(b)
 
+	needsExtraCondition := q.isSoftDelete() || q.whereFields != nil
 	if len(q.where) > 0 {
+		wrapParens := needsExtraCondition && q.whereHasOr
+		if wrapParens {
+			b = append(b, '(')
+		}
 		b, err = appendWhere(gen, b, q.where)
 		if err != nil {
 			return nil, err
+		}
+		if wrapParens {
+			b = append(b, ')')
 		}
 	}
 

--- a/query_base.go
+++ b/query_base.go
@@ -776,7 +776,7 @@ type whereBaseQuery struct {
 }
 
 func (q *whereBaseQuery) addWhere(where schema.QueryWithSep) {
-	if strings.Contains(where.Sep, "OR") {
+	if strings.Contains(strings.ToUpper(where.Sep), "OR") {
 		q.whereHasOr = true
 	}
 	q.where = append(q.where, where)

--- a/query_delete.go
+++ b/query_delete.go
@@ -109,13 +109,13 @@ func (q *DeleteQuery) WhereOr(query string, args ...any) *DeleteQuery {
 }
 
 func (q *DeleteQuery) WhereGroup(sep string, fn func(*DeleteQuery) *DeleteQuery) *DeleteQuery {
-	saved := q.where
-	q.where = nil
+	saved, savedHasOr := q.where, q.whereHasOr
+	q.where, q.whereHasOr = nil, false
 
 	q = fn(q)
 
 	where := q.where
-	q.where = saved
+	q.where, q.whereHasOr = saved, savedHasOr
 
 	q.addWhereGroup(sep, where)
 

--- a/query_select.go
+++ b/query_select.go
@@ -173,13 +173,13 @@ func (q *SelectQuery) WhereOr(query string, args ...any) *SelectQuery {
 
 // WhereGroup groups WHERE conditions with the given separator (AND/OR).
 func (q *SelectQuery) WhereGroup(sep string, fn func(*SelectQuery) *SelectQuery) *SelectQuery {
-	saved := q.where
-	q.where = nil
+	saved, savedHasOr := q.where, q.whereHasOr
+	q.where, q.whereHasOr = nil, false
 
 	q = fn(q)
 
 	where := q.where
-	q.where = saved
+	q.where, q.whereHasOr = saved, savedHasOr
 
 	q.addWhereGroup(sep, where)
 

--- a/query_select.go
+++ b/query_select.go
@@ -1214,7 +1214,8 @@ func (q *SelectQuery) Clone() *SelectQuery {
 				columns:        cloneArgs(q.columns),
 				modelTableName: q.modelTableName,
 			},
-			where: make([]schema.QueryWithSep, len(q.where)),
+			where:      make([]schema.QueryWithSep, len(q.where)),
+			whereHasOr: q.whereHasOr,
 		},
 
 		idxHintsQuery: idxHintsQuery{

--- a/query_update.go
+++ b/query_update.go
@@ -185,13 +185,13 @@ func (q *UpdateQuery) WhereOr(query string, args ...any) *UpdateQuery {
 }
 
 func (q *UpdateQuery) WhereGroup(sep string, fn func(*UpdateQuery) *UpdateQuery) *UpdateQuery {
-	saved := q.where
-	q.where = nil
+	saved, savedHasOr := q.where, q.whereHasOr
+	q.where, q.whereHasOr = nil, false
 
 	q = fn(q)
 
 	where := q.where
-	q.where = saved
+	q.where, q.whereHasOr = saved, savedHasOr
 
 	q.addWhereGroup(sep, where)
 


### PR DESCRIPTION
for #1321

When using WhereOr() with a soft-delete model, the AND deleted_at IS NULL condition was only binding to the last OR branch due to SQL operator precedence, allowing soft-deleted records to be returned through other OR branches.

Fix: track whether any WHERE condition uses OR separator via a whereHasOr flag on whereBaseQuery. When soft-delete or whereFields conditions need to be ANDed, wrap user WHERE conditions in parentheses if OR is present.

Before: WHERE (cond1) OR (cond2) AND deleted_at IS NULL
After:  WHERE ((cond1) OR (cond2)) AND deleted_at IS NULL

Also save/restore the whereHasOr flag in WhereGroup to prevent group-internal OR conditions from incorrectly triggering the outer wrapping.