### PR TITLE
fix: correct error message prefix and error type

### DIFF
--- a/bun.go
+++ b/bun.go
@@ -152,7 +152,7 @@ func List(slice any) ListValues {
 func (in ListValues) AppendQuery(gen schema.QueryGen, b []byte) (_ []byte, err error) {
 	v := reflect.ValueOf(in.slice)
 	if v.Kind() != reflect.Slice {
-		return nil, fmt.Errorf("ch: List(non-slice %T)", in.slice)
+		return nil, fmt.Errorf("bun: List(non-slice %T)", in.slice)
 	}
 
 	b = appendValues(gen, b, v)
@@ -205,7 +205,7 @@ func (in TupleValues) AppendQuery(gen schema.QueryGen, b []byte) (_ []byte, err 
 		return b, nil
 	}
 	if v.Kind() != reflect.Slice {
-		return nil, fmt.Errorf("ch: Tuple(non-slice %T)", in.slice)
+		return nil, fmt.Errorf("bun: Tuple(non-slice %T)", in.slice)
 	}
 
 	b = append(b, '(')

--- a/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-172
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mssql2019-172
@@ -1,1 +1,1 @@
-bun: feature DeleteOrderLimit is not supported by current dialect
+bun: feature DeleteReturning is not supported by current dialect

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql5-172
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql5-172
@@ -1,1 +1,1 @@
-bun: feature DeleteOrderLimit is not supported by current dialect
+bun: feature DeleteReturning is not supported by current dialect

--- a/internal/dbtest/testdata/snapshots/TestQuery-mysql8-172
+++ b/internal/dbtest/testdata/snapshots/TestQuery-mysql8-172
@@ -1,1 +1,1 @@
-bun: feature DeleteOrderLimit is not supported by current dialect
+bun: feature DeleteReturning is not supported by current dialect

--- a/query_delete.go
+++ b/query_delete.go
@@ -172,7 +172,7 @@ func (q *DeleteQuery) Limit(n int) *DeleteQuery {
 // To suppress the auto-generated RETURNING clause, use `Returning("NULL")`.
 func (q *DeleteQuery) Returning(query string, args ...any) *DeleteQuery {
 	if !q.hasFeature(feature.DeleteReturning) {
-		q.setErr(feature.NewNotSupportError(feature.DeleteOrderLimit))
+		q.setErr(feature.NewNotSupportError(feature.DeleteReturning))
 		return q
 	}
 


### PR DESCRIPTION
- Change error prefix from 'ch:' to 'bun:' in List() and Tuple() functions
- Fix DeleteQuery.Returning() to use DeleteReturning instead of DeleteOrderLimit