### PR TITLE
refactor: remove unused relationJoin.Select method

### DIFF
--- a/relation_join.go
+++ b/relation_join.go
@@ -41,12 +41,6 @@ func (j *relationJoin) applyTo(q *SelectQuery) {
 	j.columns, q.columns = q.columns, columns
 }
 
-func (j *relationJoin) Select(ctx context.Context, q *SelectQuery) error {
-	switch j.Relation.Type {
-	}
-	panic("not reached")
-}
-
 func (j *relationJoin) selectMany(ctx context.Context, q *SelectQuery) error {
 	q = j.manyQuery(q)
 	if q == nil {


### PR DESCRIPTION
This method had an empty switch statement followed by panic and was never called. The actual logic is implemented in selectJoins() which directly calls selectMany() and selectM2M().