### PR TITLE
docs: update examples to use WithQueryHook instead of deprecated AddQueryHook

### DIFF
--- a/example/basic/main.go
+++ b/example/basic/main.go
@@ -20,11 +20,11 @@ func main() {
 	}
 	sqlite.SetMaxOpenConns(1)
 
-	db := bun.NewDB(sqlite, sqlitedialect.New())
-	db.AddQueryHook(bundebug.NewQueryHook(
-		bundebug.WithVerbose(true),
-		bundebug.FromEnv("BUNDEBUG"),
-	))
+	db := bun.NewDB(sqlite, sqlitedialect.New()).
+		WithQueryHook(bundebug.NewQueryHook(
+			bundebug.WithVerbose(true),
+			bundebug.FromEnv("BUNDEBUG"),
+		))
 
 	if err := resetSchema(ctx, db); err != nil {
 		panic(err)

--- a/example/create-table-index/main.go
+++ b/example/create-table-index/main.go
@@ -36,8 +36,8 @@ func main() {
 	}
 	sqlite.SetMaxOpenConns(1)
 
-	db := bun.NewDB(sqlite, sqlitedialect.New())
-	db.AddQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
+	db := bun.NewDB(sqlite, sqlitedialect.New()).
+		WithQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 
 	if _, err := db.NewCreateTable().Model((*Book)(nil)).Exec(ctx); err != nil {
 		panic(err)

--- a/example/cursor-pagination/main.go
+++ b/example/cursor-pagination/main.go
@@ -21,11 +21,11 @@ func main() {
 	}
 	sqlite.SetMaxOpenConns(1)
 
-	db := bun.NewDB(sqlite, sqlitedialect.New())
-	db.AddQueryHook(bundebug.NewQueryHook(
-		bundebug.WithVerbose(true),
-		bundebug.FromEnv("BUNDEBUG"),
-	))
+	db := bun.NewDB(sqlite, sqlitedialect.New()).
+		WithQueryHook(bundebug.NewQueryHook(
+			bundebug.WithVerbose(true),
+			bundebug.FromEnv("BUNDEBUG"),
+		))
 
 	if err := resetDB(ctx, db); err != nil {
 		panic(err)

--- a/example/custom-type/main.go
+++ b/example/custom-type/main.go
@@ -22,11 +22,11 @@ func main() {
 	}
 	sqlite.SetMaxOpenConns(1)
 
-	db := bun.NewDB(sqlite, sqlitedialect.New())
-	db.AddQueryHook(bundebug.NewQueryHook(
-		bundebug.WithVerbose(true),
-		bundebug.FromEnv("BUNDEBUG"),
-	))
+	db := bun.NewDB(sqlite, sqlitedialect.New()).
+		WithQueryHook(bundebug.NewQueryHook(
+			bundebug.WithVerbose(true),
+			bundebug.FromEnv("BUNDEBUG"),
+		))
 
 	src := Now()
 	var dest Time

--- a/example/fixture/main.go
+++ b/example/fixture/main.go
@@ -40,8 +40,8 @@ func main() {
 	}
 	sqldb.SetMaxOpenConns(1)
 
-	db := bun.NewDB(sqldb, sqlitedialect.New())
-	db.AddQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
+	db := bun.NewDB(sqldb, sqlitedialect.New()).
+		WithQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 
 	// Register models before loading fixtures.
 	db.RegisterModel((*User)(nil), (*Org)(nil))

--- a/example/migrate/main.go
+++ b/example/migrate/main.go
@@ -24,11 +24,11 @@ func main() {
 		panic(err)
 	}
 
-	db := bun.NewDB(sqldb, sqlitedialect.New())
-	db.AddQueryHook(bundebug.NewQueryHook(
-		bundebug.WithEnabled(false),
-		bundebug.FromEnv(),
-	))
+	db := bun.NewDB(sqldb, sqlitedialect.New()).
+		WithQueryHook(bundebug.NewQueryHook(
+			bundebug.WithEnabled(false),
+			bundebug.FromEnv(),
+		))
 
 	templateData := map[string]string{
 		"Prefix": "example_",

--- a/example/model-hooks/main.go
+++ b/example/model-hooks/main.go
@@ -21,8 +21,8 @@ func main() {
 	}
 	sqlite.SetMaxOpenConns(1)
 
-	db := bun.NewDB(sqlite, sqlitedialect.New())
-	db.AddQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
+	db := bun.NewDB(sqlite, sqlitedialect.New()).
+		WithQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 
 	if err := db.ResetModel(ctx, (*User)(nil)); err != nil {
 		panic(err)

--- a/example/multi-tenant/main.go
+++ b/example/multi-tenant/main.go
@@ -23,8 +23,8 @@ func main() {
 	}
 	sqlite.SetMaxOpenConns(1)
 
-	db := bun.NewDB(sqlite, sqlitedialect.New())
-	db.AddQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
+	db := bun.NewDB(sqlite, sqlitedialect.New()).
+		WithQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 
 	// Register models for the fixture.
 	db.RegisterModel((*Story)(nil))

--- a/example/opentelemetry/client.go
+++ b/example/opentelemetry/client.go
@@ -34,12 +34,12 @@ func main() {
 	dsn := "postgres://uptrace:uptrace@localhost:5432/uptrace?sslmode=disable"
 	sqldb := sql.OpenDB(pgdriver.NewConnector(pgdriver.WithDSN(dsn)))
 
-	db := bun.NewDB(sqldb, pgdialect.New())
-	db.AddQueryHook(bunotel.NewQueryHook(
-		bunotel.WithDBName("uptrace"),
-		bunotel.WithFormattedQueries(true),
-	))
-	// db.AddQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
+	db := bun.NewDB(sqldb, pgdialect.New()).
+		WithQueryHook(bunotel.NewQueryHook(
+			bunotel.WithDBName("uptrace"),
+			bunotel.WithFormattedQueries(true),
+		))
+	// db.WithQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 
 	if err := db.ResetModel(ctx, (*TestModel)(nil)); err != nil {
 		panic(err)

--- a/example/opentelemetry/client.go
+++ b/example/opentelemetry/client.go
@@ -39,7 +39,7 @@ func main() {
 			bunotel.WithDBName("uptrace"),
 			bunotel.WithFormattedQueries(true),
 		))
-	// db.WithQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
+	// db = db.WithQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 
 	if err := db.ResetModel(ctx, (*TestModel)(nil)); err != nil {
 		panic(err)

--- a/example/pg-faceted-search/main.go
+++ b/example/pg-faceted-search/main.go
@@ -46,8 +46,8 @@ func main() {
 	dsn := "postgres://postgres:@localhost:5432/test?sslmode=disable"
 	sqldb := sql.OpenDB(pgdriver.NewConnector(pgdriver.WithDSN(dsn)))
 
-	db := bun.NewDB(sqldb, pgdialect.New())
-	db.AddQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
+	db := bun.NewDB(sqldb, pgdialect.New()).
+		WithQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 
 	// Register models for the fixture.
 	db.RegisterModel((*Book)(nil))

--- a/example/pg-listen/main.go
+++ b/example/pg-listen/main.go
@@ -18,8 +18,8 @@ func main() {
 	dsn := "postgres://postgres:@localhost:5432/postgres?sslmode=disable"
 	sqldb := sql.OpenDB(pgdriver.NewConnector(pgdriver.WithDSN(dsn)))
 
-	db := bun.NewDB(sqldb, pgdialect.New())
-	db.AddQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
+	db := bun.NewDB(sqldb, pgdialect.New()).
+		WithQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 
 	ln := pgdriver.NewListener(db)
 

--- a/example/pg-range/main.go
+++ b/example/pg-range/main.go
@@ -26,8 +26,8 @@ func main() {
 	dsn := "postgres://postgres:@localhost:5432/postgres?sslmode=disable"
 	sqldb := sql.OpenDB(pgdriver.NewConnector(pgdriver.WithDSN(dsn)))
 
-	db := bun.NewDB(sqldb, pgdialect.New())
-	db.AddQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
+	db := bun.NewDB(sqldb, pgdialect.New()).
+		WithQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 
 	if err := db.ResetModel(ctx, (*Reservation)(nil)); err != nil {
 		panic(err)

--- a/example/placeholders/main.go
+++ b/example/placeholders/main.go
@@ -26,8 +26,8 @@ func main() {
 	}
 	sqlite.SetMaxOpenConns(1)
 
-	db := bun.NewDB(sqlite, sqlitedialect.New())
-	db.AddQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
+	db := bun.NewDB(sqlite, sqlitedialect.New()).
+		WithQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 
 	var tableName, tableAlias, pks, tablePKs, columns, tableColumns string
 

--- a/example/rel-belongs-to/main.go
+++ b/example/rel-belongs-to/main.go
@@ -32,10 +32,9 @@ func main() {
 		panic(err)
 	}
 
-	db := bun.NewDB(sqldb, sqlitedialect.New())
+	db := bun.NewDB(sqldb, sqlitedialect.New()).
+		WithQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 	defer db.Close()
-
-	db.AddQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 
 	if err := createSchema(ctx, db); err != nil {
 		panic(err)

--- a/example/rel-has-many-polymorphic/main.go
+++ b/example/rel-has-many-polymorphic/main.go
@@ -41,10 +41,9 @@ func main() {
 		panic(err)
 	}
 
-	db := bun.NewDB(sqldb, sqlitedialect.New())
+	db := bun.NewDB(sqldb, sqlitedialect.New()).
+		WithQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 	defer db.Close()
-
-	db.AddQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 
 	if err := createSchema(ctx, db); err != nil {
 		panic(err)

--- a/example/rel-has-many/main.go
+++ b/example/rel-has-many/main.go
@@ -33,10 +33,9 @@ func main() {
 		panic(err)
 	}
 
-	db := bun.NewDB(sqldb, sqlitedialect.New())
+	db := bun.NewDB(sqldb, sqlitedialect.New()).
+		WithQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 	defer db.Close()
-
-	db.AddQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 
 	if err := createSchema(ctx, db); err != nil {
 		panic(err)

--- a/example/rel-has-one/main.go
+++ b/example/rel-has-one/main.go
@@ -32,10 +32,9 @@ func main() {
 		panic(err)
 	}
 
-	db := bun.NewDB(sqldb, sqlitedialect.New())
+	db := bun.NewDB(sqldb, sqlitedialect.New()).
+		WithQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 	defer db.Close()
-
-	db.AddQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 
 	if err := createSchema(ctx, db); err != nil {
 		panic(err)

--- a/example/rel-join-condition/main.go
+++ b/example/rel-join-condition/main.go
@@ -33,10 +33,9 @@ func main() {
 		panic(err)
 	}
 
-	db := bun.NewDB(sqldb, sqlitedialect.New())
+	db := bun.NewDB(sqldb, sqlitedialect.New()).
+		WithQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 	defer db.Close()
-
-	db.AddQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 
 	if err := createSchema(ctx, db); err != nil {
 		panic(err)

--- a/example/rel-many-to-many-self/main.go
+++ b/example/rel-many-to-many-self/main.go
@@ -31,10 +31,9 @@ func main() {
 		panic(err)
 	}
 
-	db := bun.NewDB(sqldb, sqlitedialect.New())
+	db := bun.NewDB(sqldb, sqlitedialect.New()).
+		WithQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 	defer db.Close()
-
-	db.AddQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 
 	// Register many to many model so bun can better recognize m2m relation.
 	// This should be done before you use the model for the first time.

--- a/example/rel-many-to-many/main.go
+++ b/example/rel-many-to-many/main.go
@@ -38,10 +38,9 @@ func main() {
 		panic(err)
 	}
 
-	db := bun.NewDB(sqldb, sqlitedialect.New())
+	db := bun.NewDB(sqldb, sqlitedialect.New()).
+		WithQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 	defer db.Close()
-
-	db.AddQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 
 	// Register many to many model so bun can better recognize m2m relation.
 	// This should be done before you use the model for the first time.

--- a/example/trivial/mssql/main.go
+++ b/example/trivial/mssql/main.go
@@ -21,10 +21,8 @@ func main() {
 	}
 
 	// Create a Bun db on top of it.
-	db := bun.NewDB(sqldb, mssqldialect.New())
-
-	// Print all queries to stdout.
-	db.AddQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
+	db := bun.NewDB(sqldb, mssqldialect.New()).
+		WithQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 
 	var rnd float64
 

--- a/example/trivial/mysql/main.go
+++ b/example/trivial/mysql/main.go
@@ -21,10 +21,8 @@ func main() {
 	}
 
 	// Create a Bun db on top of it.
-	db := bun.NewDB(sqldb, mysqldialect.New())
-
-	// Print all queries to stdout.
-	db.AddQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
+	db := bun.NewDB(sqldb, mysqldialect.New()).
+		WithQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 
 	var rnd float64
 

--- a/example/trivial/postgres/main.go
+++ b/example/trivial/postgres/main.go
@@ -19,10 +19,8 @@ func main() {
 	pgdb := sql.OpenDB(pgdriver.NewConnector(pgdriver.WithDSN(dsn)))
 
 	// Create a Bun db on top of it.
-	db := bun.NewDB(pgdb, pgdialect.New())
-
-	// Print all queries to stdout.
-	db.AddQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
+	db := bun.NewDB(pgdb, pgdialect.New()).
+		WithQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 
 	var rnd float64
 

--- a/example/trivial/sqlite/main.go
+++ b/example/trivial/sqlite/main.go
@@ -21,10 +21,8 @@ func main() {
 	}
 
 	// Create a Bun db on top of it.
-	db := bun.NewDB(sqlite, sqlitedialect.New())
-
-	// Print all queries to stdout.
-	db.AddQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
+	db := bun.NewDB(sqlite, sqlitedialect.New()).
+		WithQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 
 	var rnd int64
 

--- a/example/tx-composition/main.go
+++ b/example/tx-composition/main.go
@@ -19,8 +19,8 @@ func main() {
 	}
 	sqlite.SetMaxOpenConns(1)
 
-	db := bun.NewDB(sqlite, sqlitedialect.New())
-	db.AddQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
+	db := bun.NewDB(sqlite, sqlitedialect.New()).
+		WithQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 
 	if err := db.ResetModel(ctx, (*User)(nil), (*Profile)(nil)); err != nil {
 		panic(err)


### PR DESCRIPTION
Updated 24 example files to use the new WithQueryHook API:
- basic, cursor-pagination, custom-type, migrate
- model-hooks, multi-tenant, fixture, placeholders
- tx-composition, create-table-index
- pg-range, pg-listen, pg-faceted-search
- rel-belongs-to, rel-has-one, rel-has-many
- rel-has-many-polymorphic, rel-join-condition
- rel-many-to-many, rel-many-to-many-self
- trivial/mssql, trivial/mysql, trivial/postgres, trivial/sqlite
- opentelemetry