### PR TITLE
fix: detect duplicate migration IDs during Discover

### DIFF
--- a/migrate/migrations.go
+++ b/migrate/migrations.go
@@ -106,7 +106,15 @@ func (m *Migrations) Discover(fsys fs.FS) error {
 		}
 
 		migration := m.getOrCreateMigration(name)
+
+		if migration.Comment != "" && migration.Comment != comment {
+			return fmt.Errorf(
+				"migrate: duplicate migration ID %s (files %s and %s)",
+				name, migration.Comment, comment,
+			)
+		}
 		migration.Comment = comment
+
 		migrationFunc := newSQLMigrationFunc(fsys, path)
 
 		if strings.HasSuffix(path, ".up.sql") {

--- a/migrate/migrations_test.go
+++ b/migrate/migrations_test.go
@@ -1,0 +1,72 @@
+package migrate
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+func TestDiscoverDuplicateMigrationID(t *testing.T) {
+	fsys := fstest.MapFS{
+		"20260228140000_foo.tx.up.sql":   &fstest.MapFile{Data: []byte("SELECT 1")},
+		"20260228140000_bar.tx.up.sql":   &fstest.MapFile{Data: []byte("SELECT 2")},
+		"20260228150000_baz.tx.up.sql":   &fstest.MapFile{Data: []byte("SELECT 3")},
+		"20260228150000_baz.tx.down.sql": &fstest.MapFile{Data: []byte("SELECT 4")},
+	}
+
+	migrations := NewMigrations()
+	err := migrations.Discover(fsys)
+	if err == nil {
+		t.Fatal("expected error for duplicate migration ID")
+	}
+	if got := err.Error(); !strings.Contains(got, "duplicate migration ID") || !strings.Contains(got, "20260228140000") {
+		t.Fatalf("unexpected error: %s", got)
+	}
+}
+
+func TestDiscoverDuplicateDownMigration(t *testing.T) {
+	fsys := fstest.MapFS{
+		"20260228140000_foo.tx.down.sql": &fstest.MapFile{Data: []byte("SELECT 1")},
+		"20260228140000_bar.tx.down.sql": &fstest.MapFile{Data: []byte("SELECT 2")},
+	}
+
+	migrations := NewMigrations()
+	err := migrations.Discover(fsys)
+	if err == nil {
+		t.Fatal("expected error for duplicate migration ID")
+	}
+	if got := err.Error(); !strings.Contains(got, "duplicate migration ID") {
+		t.Fatalf("unexpected error: %s", got)
+	}
+}
+
+func TestDiscoverDuplicateMixedUpDown(t *testing.T) {
+	fsys := fstest.MapFS{
+		"20260228140000_foo.tx.up.sql":   &fstest.MapFile{Data: []byte("SELECT 1")},
+		"20260228140000_bar.tx.down.sql": &fstest.MapFile{Data: []byte("SELECT 2")},
+	}
+
+	migrations := NewMigrations()
+	err := migrations.Discover(fsys)
+	if err == nil {
+		t.Fatal("expected error for duplicate migration ID")
+	}
+	if got := err.Error(); !strings.Contains(got, "duplicate migration ID") {
+		t.Fatalf("unexpected error: %s", got)
+	}
+}
+
+func TestDiscoverNoDuplicate(t *testing.T) {
+	fsys := fstest.MapFS{
+		"20260228140000_foo.tx.up.sql":   &fstest.MapFile{Data: []byte("SELECT 1")},
+		"20260228140000_foo.tx.down.sql": &fstest.MapFile{Data: []byte("SELECT 2")},
+		"20260228150000_bar.tx.up.sql":   &fstest.MapFile{Data: []byte("SELECT 3")},
+	}
+
+	migrations := NewMigrations()
+	err := migrations.Discover(fsys)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+


### PR DESCRIPTION
Return an error when two migration files share the same ID but have different base filenames, preventing silent overwrites.