### PR TITLE
fix: resolve nested Relation() with circular struct composition

### DIFF
--- a/schema/issue1243_test.go
+++ b/schema/issue1243_test.go
@@ -1,0 +1,77 @@
+package schema
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Models for TestNestedRelationWithSharedComposition (issue #1243).
+// These must be at package level to allow circular type references
+// between Business and Lead via shared embedded relation structs.
+
+type issue1243IDField struct {
+	ID int64 `bun:",pk,autoincrement"`
+}
+
+type issue1243Business struct {
+	issue1243IDField
+	issue1243LeadRelation
+}
+
+type issue1243BusinessRelation struct {
+	BusinessID int64              `bun:",nullzero"`
+	Business   *issue1243Business `bun:"rel:belongs-to,join:business_id=id"`
+}
+
+type issue1243Lead struct {
+	issue1243IDField
+	issue1243BusinessRelation
+}
+
+type issue1243LeadRelation struct {
+	LeadID int64          `bun:",nullzero"`
+	Lead   *issue1243Lead `bun:"rel:belongs-to,join:lead_id=id"`
+}
+
+type issue1243Agent struct {
+	issue1243IDField
+	issue1243BusinessRelation
+
+	Associations []*issue1243Link `bun:"rel:has-many,join:id=agent_id"`
+}
+
+type issue1243AgentRelation struct {
+	AgentID int64           `bun:",nullzero"`
+	Agent   *issue1243Agent `bun:"rel:belongs-to,join:agent_id=id"`
+}
+
+type issue1243Link struct {
+	issue1243IDField
+	issue1243AgentRelation
+	issue1243LeadRelation
+}
+
+func TestNestedRelationWithSharedComposition(t *testing.T) {
+	dialect := newNopDialect()
+	tables := NewTables(dialect)
+
+	// Initialize Link table, which triggers circular initialization:
+	// Link -> AgentRelation -> Agent -> BusinessRelation -> Business
+	//   -> LeadRelation -> Lead -> BusinessRelation -> Business (cycle)
+	linkTable := tables.Get(reflect.TypeFor[*issue1243Link]())
+
+	require.Contains(t, linkTable.StructMap, "lead",
+		"Link should have 'lead' in StructMap from embedded LeadRelation")
+
+	leadTable := linkTable.StructMap["lead"].Table
+	require.Contains(t, leadTable.StructMap, "business",
+		"Lead should have 'business' in StructMap from embedded BusinessRelation")
+
+	// This is the lookup that fails in issue #1243:
+	// when scanning column "lead__business__id" from a nested Relation() query.
+	field := linkTable.LookupField("lead__business__id")
+	require.NotNil(t, field,
+		"LookupField('lead__business__id') must resolve through Lead -> Business")
+}

--- a/schema/issue1243_test.go
+++ b/schema/issue1243_test.go
@@ -11,46 +11,46 @@ import (
 // These must be at package level to allow circular type references
 // between Business and Lead via shared embedded relation structs.
 
-type issue1243IDField struct {
+type idField struct {
 	ID int64 `bun:",pk,autoincrement"`
 }
 
-type issue1243Business struct {
-	issue1243IDField
-	issue1243LeadRelation
+type business struct {
+	idField
+	leadRelation
 }
 
-type issue1243BusinessRelation struct {
-	BusinessID int64              `bun:",nullzero"`
-	Business   *issue1243Business `bun:"rel:belongs-to,join:business_id=id"`
+type businessRelation struct {
+	BusinessID int64     `bun:",nullzero"`
+	Business   *business `bun:"rel:belongs-to,join:business_id=id"`
 }
 
-type issue1243Lead struct {
-	issue1243IDField
-	issue1243BusinessRelation
+type lead struct {
+	idField
+	businessRelation
 }
 
-type issue1243LeadRelation struct {
-	LeadID int64          `bun:",nullzero"`
-	Lead   *issue1243Lead `bun:"rel:belongs-to,join:lead_id=id"`
+type leadRelation struct {
+	LeadID int64 `bun:",nullzero"`
+	Lead   *lead `bun:"rel:belongs-to,join:lead_id=id"`
 }
 
-type issue1243Agent struct {
-	issue1243IDField
-	issue1243BusinessRelation
+type agent struct {
+	idField
+	businessRelation
 
-	Associations []*issue1243Link `bun:"rel:has-many,join:id=agent_id"`
+	Associations []*link `bun:"rel:has-many,join:id=agent_id"`
 }
 
-type issue1243AgentRelation struct {
-	AgentID int64           `bun:",nullzero"`
-	Agent   *issue1243Agent `bun:"rel:belongs-to,join:agent_id=id"`
+type agentRelation struct {
+	AgentID int64  `bun:",nullzero"`
+	Agent   *agent `bun:"rel:belongs-to,join:agent_id=id"`
 }
 
-type issue1243Link struct {
-	issue1243IDField
-	issue1243AgentRelation
-	issue1243LeadRelation
+type link struct {
+	idField
+	agentRelation
+	leadRelation
 }
 
 func TestNestedRelationWithSharedComposition(t *testing.T) {
@@ -60,7 +60,7 @@ func TestNestedRelationWithSharedComposition(t *testing.T) {
 	// Initialize Link table, which triggers circular initialization:
 	// Link -> AgentRelation -> Agent -> BusinessRelation -> Business
 	//   -> LeadRelation -> Lead -> BusinessRelation -> Business (cycle)
-	linkTable := tables.Get(reflect.TypeFor[*issue1243Link]())
+	linkTable := tables.Get(reflect.TypeFor[*link]())
 
 	require.Contains(t, linkTable.StructMap, "lead",
 		"Link should have 'lead' in StructMap from embedded LeadRelation")

--- a/schema/table.go
+++ b/schema/table.go
@@ -69,7 +69,8 @@ type Table struct {
 	SoftDeleteField       *Field
 	UpdateSoftDeleteField func(fv reflect.Value, tm time.Time) error
 
-	flags internal.Flag
+	flags       internal.Flag
+	initStarted bool
 }
 
 type structField struct {
@@ -233,10 +234,16 @@ func (t *Table) processFields(typ reflect.Type) {
 			if t.StructMap == nil {
 				t.StructMap = make(map[string]*structField)
 			}
+			// Register the StructMap entry with a placeholder table BEFORE
+			// triggering recursive initialization. This ensures that types in
+			// a circular dependency can find this entry during their own
+			// processFields, even if this table's init hasn't completed yet.
+			placeholder := t.dialect.Tables().Placeholder(field.IndirectType)
 			t.StructMap[field.Name] = &structField{
 				Index: field.Index,
-				Table: t.dialect.Tables().InProgress(field.IndirectType),
+				Table: placeholder,
 			}
+			t.dialect.Tables().InProgress(field.IndirectType)
 		}
 	}
 

--- a/schema/table.go
+++ b/schema/table.go
@@ -79,6 +79,10 @@ type structField struct {
 }
 
 func (table *Table) init(dialect Dialect, typ reflect.Type) {
+	if table.initStarted {
+		return
+	}
+	table.initStarted = true
 	table.dialect = dialect
 	table.Type = typ
 	table.ZeroValue = reflect.New(table.Type).Elem()

--- a/schema/tables.go
+++ b/schema/tables.go
@@ -67,13 +67,32 @@ func (t *Tables) Get(typ reflect.Type) *Table {
 
 func (t *Tables) InProgress(typ reflect.Type) *Table {
 	if table, ok := t.inProgress[typ]; ok {
+		if !table.initStarted {
+			table.initStarted = true
+			table.init(t.dialect, typ)
+		}
 		return table
 	}
 
 	table := new(Table)
+	table.initStarted = true
 	t.inProgress[typ] = table
 	table.init(t.dialect, typ)
 
+	return table
+}
+
+// Placeholder returns an existing in-progress table or creates a new
+// uninitialized placeholder entry. This allows callers to register
+// StructMap entries with the table pointer before triggering recursive
+// initialization via InProgress, preventing missing entries in circular
+// dependency chains.
+func (t *Tables) Placeholder(typ reflect.Type) *Table {
+	if table, ok := t.inProgress[typ]; ok {
+		return table
+	}
+	table := new(Table)
+	t.inProgress[typ] = table
 	return table
 }
 

--- a/schema/tables.go
+++ b/schema/tables.go
@@ -65,34 +65,25 @@ func (t *Tables) Get(typ reflect.Type) *Table {
 	return table
 }
 
+// InProgress returns the in-progress table for typ, initializing it
+// if it has not been initialized yet. The Placeholder + init() split
+// lets callers register StructMap entries with the table pointer
+// before triggering recursive initialization, preventing missing
+// entries in circular dependency chains.
 func (t *Tables) InProgress(typ reflect.Type) *Table {
-	if table, ok := t.inProgress[typ]; ok {
-		if !table.initStarted {
-			table.initStarted = true
-			table.init(t.dialect, typ)
-		}
-		return table
-	}
-
-	table := new(Table)
-	table.initStarted = true
-	t.inProgress[typ] = table
+	table := t.Placeholder(typ)
 	table.init(t.dialect, typ)
-
 	return table
 }
 
 // Placeholder returns an existing in-progress table or creates a new
-// uninitialized placeholder entry. This allows callers to register
-// StructMap entries with the table pointer before triggering recursive
-// initialization via InProgress, preventing missing entries in circular
-// dependency chains.
+// uninitialized placeholder entry.
 func (t *Tables) Placeholder(typ reflect.Type) *Table {
-	if table, ok := t.inProgress[typ]; ok {
-		return table
+	table, ok := t.inProgress[typ]
+	if !ok {
+		table = new(Table)
+		t.inProgress[typ] = table
 	}
-	table := new(Table)
-	t.inProgress[typ] = table
 	return table
 }
 


### PR DESCRIPTION
When models use shared embedded relation structs that form circular dependencies (e.g. Business -> LeadRelation -> Lead -> BusinessRelation -> Business), `LookupField` fails for nested columns like `lead__business__id` because `StructMap` entries are missing due to initialization order.

The fix splits struct field registration into a `Placeholder` step (registers the StructMap entry with the table pointer) before triggering recursive `InProgress` initialization. This ensures StructMap entries are visible to types in the same circular dependency chain during their own `processFields`.

Fixes #1243