### PR TITLE
fix(migrate): ignore --bun:skip with a blank query

### DIFF
--- a/migrate/migration.go
+++ b/migrate/migration.go
@@ -107,8 +107,10 @@ func newSQLMigrationFunc(fsys fs.FS, name string) internalMigrationFunc {
 				return fmt.Errorf("bun: unknown directive: %q", b)
 			}
 
-			query = append(query, b...)
-			query = append(query, '\n')
+			if len(bytes.TrimSpace(b)) > 0 {
+				query = append(query, b...)
+				query = append(query, '\n')
+			}
 		}
 
 		if len(query) > 0 {


### PR DESCRIPTION
Resolves #1114 

Placing `--bun:split` at the top of the file, directly under another `--bun:split`, or, more generally, before we encounter an SQL statement, executing the migrations in this file produces a blank transaction. This will not corrupt the schema, but might be confusing to the user.

This PR addresses it by saying only non-empty queries can be split by `--bun:split` directive.
We also skip any blank lines, as this simplifies checking if `query` contains an SQL statement.
