### PR TITLE
fix(automigrate): include scanonly fields in the BunModelInspector output

### DIFF
--- a/internal/dbtest/inspect_test.go
+++ b/internal/dbtest/inspect_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/dialect/sqltype"
@@ -587,6 +588,7 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 				return
 			}
 		})
+
 		t.Run("collects primary keys", func(t *testing.T) {
 			type Model struct {
 				ID       string    `bun:",pk"`
@@ -656,6 +658,30 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 				require.Equal(t, "keep_me", table.GetName(), "wrong table name")
 				return
 			}
+		})
+
+		t.Run("includes scanonly columns", func(t *testing.T) {
+			type Number struct {
+				Positive int
+				Negative int `bun:",scanonly"` // SELECT positive, -positive as negative
+			}
+
+			tables := schema.NewTables(dialect)
+			tables.Register((*Number)(nil))
+			inspector := sqlschema.NewBunModelInspector(tables, sqlschema.WithSchemaName(dialect.DefaultSchema()))
+
+			got, err := inspector.Inspect(t.Context())
+			require.NoError(t, err)
+
+			gotTables := got.GetTables()
+			require.Len(t, gotTables, 1)
+
+			var columns []string
+			for _, c := range gotTables[0].GetColumns() {
+				columns = append(columns, c.GetName())
+			}
+			assert.Len(t, columns, 2)
+			require.Subset(t, []string{"positive", "negative"}, columns)
 		})
 	})
 }

--- a/migrate/sqlschema/inspector.go
+++ b/migrate/sqlschema/inspector.go
@@ -141,7 +141,7 @@ func (bmi *BunModelInspector) Inspect(ctx context.Context) (Database, error) {
 		}
 
 		var columns []Column
-		for _, f := range t.Fields {
+		for _, f := range t.FieldMap {
 
 			sqlType, length, err := parseLen(f.CreateTableSQLType)
 			if err != nil {

--- a/schema/table.go
+++ b/schema/table.go
@@ -53,13 +53,13 @@ type Table struct {
 	Alias             string
 	SQLAlias          Safe
 
-	allFields  []*Field // all fields including scanonly
+	allFields  []*Field // All fields, including scanonly
 	Fields     []*Field // PKs + DataFields
 	PKs        []*Field
 	DataFields []*Field
 	relFields  []*Field
 
-	FieldMap  map[string]*Field
+	FieldMap  map[string]*Field // Fields keyed by Go field name, excl. rel and m2m fields.
 	StructMap map[string]*structField
 
 	IsM2MTable bool // If true, this table is the "junction table" of an m2m relation.


### PR DESCRIPTION
Resolves #1295 

BunModelInspector collects columns from `Table.Fields`, which does not include `scanonly` fields. This leads AutoMigrator to believe they should be dropped from the DB schema.

Instead, it should be collecting columns from `Table.FieldMap`, which also includes `scanonly` fields.