### PR TITLE
fix(db): propagate transaction context into RunInTx callback

### DIFF
--- a/db.go
+++ b/db.go
@@ -547,7 +547,7 @@ func (c Conn) RunInTx(
 		}
 	}()
 
-	if err := fn(ctx, tx); err != nil {
+	if err := fn(tx.ctx, tx); err != nil {
 		return err
 	}
 
@@ -620,7 +620,7 @@ func (db *DB) RunInTx(
 		}
 	}()
 
-	if err := fn(ctx, tx); err != nil {
+	if err := fn(tx.ctx, tx); err != nil {
 		return err
 	}
 
@@ -793,7 +793,7 @@ func (tx Tx) RunInTx(
 		}
 	}()
 
-	if err := fn(ctx, sp); err != nil {
+	if err := fn(tx.ctx, sp); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
fix: #1367 

## Summary
`RunInTx` was passing the original `ctx` into the callback instead of the transaction context (`tx.ctx`). This breaks context propagation for anything initialized during `BeginTx`.
## Details
In Bun, OpenTelemetry instrumentation is typically added via query hooks. Those hooks rely on the context to carry the active span.
During `BeginTx`, Bun creates a wrapped context (`tx.ctx`) that includes the transaction span (`BEGIN`). However, the callback was invoked with the outer `ctx`, so all queries inside the transaction were executed outside of that span.
As a result:
queries inside the transaction are not children of the `BEGIN` span
trace structure is inconsistent (`COMMIT/ROLLBACK` are correct, queries are not)
## Fix
Pass `tx.ctx` into the callback:
`fn(tx.ctx, tx)`
Applied to:
- `Conn.RunInTx`
- `DB.RunInTx`
- `Tx.RunInTx`
## Result
All queries inside a transaction now inherit the transaction span created at `BEGIN`, producing a correct and consistent trace tree.