### PR TITLE
fix: prevent SQL injection via driver.Valuer error messages

### DIFF
--- a/dialect/append.go
+++ b/dialect/append.go
@@ -8,9 +8,23 @@ import (
 )
 
 func AppendError(b []byte, err error) []byte {
-	b = append(b, "?!("...)
-	b = append(b, err.Error()...)
-	b = append(b, ')')
+	b = append(b, "?!('"...)
+	b = appendSanitizedError(b, err.Error())
+	b = append(b, "')"...)
+	return b
+}
+
+// appendSanitizedError escapes single quotes in error messages to prevent
+// SQL injection when driver.Valuer returns an error that gets embedded in
+// the query string.
+func appendSanitizedError(b []byte, s string) []byte {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\'' {
+			b = append(b, '\'', '\'')
+		} else {
+			b = append(b, s[i])
+		}
+	}
 	return b
 }
 


### PR DESCRIPTION
## Security Fix

Fixes #1307

### Problem

`AppendError` embeds error messages directly into the SQL query string without any escaping. A `driver.Valuer` implementation can return an error with a crafted message that closes the `?!()` wrapper and injects arbitrary SQL.

### Fix

Wrap the error message in single quotes and escape embedded single quotes within the message. This ensures the error message is always treated as a string literal, preventing SQL injection regardless of the error content.

```
Before: ?!(crafted SQL injection here)
After:  ?!('crafted SQL injection here')
```
