### PR TITLE
feat: no ErrNoRows when scan nil struct ptr

### DIFF
--- a/internal/dbtest/db_test.go
+++ b/internal/dbtest/db_test.go
@@ -262,6 +262,7 @@ func TestDB(t *testing.T) {
 		{testSelectMap},
 		{testSelectMapSlice},
 		{testSelectStruct},
+		{testSelectStructNilPtr},
 		{testSelectNestedStructValue},
 		{testSelectNestedStructPtr},
 		{testSelectStructSlice},
@@ -442,6 +443,48 @@ func testSelectStruct(t *testing.T, db *bun.DB) {
 	err = db.NewSelect().ColumnExpr("1 as unknown_column").Scan(ctx, model)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Model does not have column")
+}
+
+func testSelectStructNilPtr(t *testing.T, db *bun.DB) {
+	type Model struct {
+		Num int
+		Str string
+	}
+
+	// Scan a row into a nil **Model: the inner pointer should be allocated and populated.
+	var model *Model
+	err := db.NewSelect().
+		ColumnExpr("10 AS num, 'hello' AS str").
+		Scan(ctx, &model)
+	require.NoError(t, err)
+	require.NotNil(t, model)
+	require.Equal(t, 10, model.Num)
+	require.Equal(t, "hello", model.Str)
+
+	// No rows + nil **Model: should NOT return ErrNoRows; inner pointer stays nil.
+	var empty *Model
+	err = db.NewSelect().
+		TableExpr("(SELECT 42 AS num) AS t").
+		Where("1 = 2").
+		Scan(ctx, &empty)
+	require.NoError(t, err)
+	require.Nil(t, empty)
+
+	err = db.NewSelect().
+		Model(&empty).
+		TableExpr("(SELECT 42 AS num) AS t").
+		Where("1 = 2").
+		Scan(ctx)
+	require.NoError(t, err)
+	require.Nil(t, empty)
+
+	// Regression: a non-nil *Model (existing behaviour) must still return ErrNoRows.
+	nonNil := new(Model)
+	err = db.NewSelect().
+		TableExpr("(SELECT 42 AS num) AS t").
+		Where("1 = 2").
+		Scan(ctx, nonNil)
+	require.Equal(t, sql.ErrNoRows, err)
 }
 
 func testSelectNestedStructValue(t *testing.T, db *bun.DB) {

--- a/model.go
+++ b/model.go
@@ -122,7 +122,7 @@ func _newModel(db *DB, dest any, scan bool) (Model, error) {
 		}
 		mapPtr := v.Addr().Interface().(*map[string]any)
 		return newMapModel(db, mapPtr), nil
-	case reflect.Struct:
+	case reflect.Struct, reflect.Pointer:
 		return newStructTableModelValue(db, dest, v), nil
 	case reflect.Slice:
 		switch elemType := sliceElemType(v); elemType.Kind() {

--- a/query_base.go
+++ b/query_base.go
@@ -6,6 +6,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -630,7 +631,24 @@ func (q *baseQuery) _scan(
 	}
 
 	if numRow == 0 && hasDest && isSingleRowModel(model) {
-		return nil, sql.ErrNoRows
+		var rv reflect.Value
+		if v, ok := model.Value().(reflect.Value); ok {
+			rv = v
+		} else {
+			rv = reflect.ValueOf(model.Value())
+		}
+		for rv.Kind() == reflect.Pointer {
+			rv = rv.Elem()
+		}
+		switch rv.Kind() {
+		case reflect.Invalid:
+		case reflect.Map, reflect.Slice:
+			if !rv.IsNil() {
+				return nil, sql.ErrNoRows
+			}
+		default:
+			return nil, sql.ErrNoRows
+		}
 	}
 	return driver.RowsAffected(numRow), nil
 }


### PR DESCRIPTION
### previous writing styles
```
user := new(User)
err := db.NewSelect().Model(usert). Where("id = ?", 1).Scan(ctx)
// If there is no data that meets the criteria，err = sql.ErrNoRows， user != nil
```

###  new feature
```
var user *User
err := db.NewSelect().Model(&usert). Where("id = ?", 1).Scan(ctx)
If there is no data that meets the criteria，err = nil， user = nil
```
Compatible with previous writing styles
