### PR TITLE
feat: no ErrNoRows when scan nil struct ptr and nil map and  nil builtin type ptr

### DIFF
--- a/internal/dbtest/db_test.go
+++ b/internal/dbtest/db_test.go
@@ -262,6 +262,7 @@ func TestDB(t *testing.T) {
 		{testSelectMap},
 		{testSelectMapSlice},
 		{testSelectStruct},
+		{testSelectStructNilPtr},
 		{testSelectNestedStructValue},
 		{testSelectNestedStructPtr},
 		{testSelectStructSlice},
@@ -442,6 +443,51 @@ func testSelectStruct(t *testing.T, db *bun.DB) {
 	err = db.NewSelect().ColumnExpr("1 as unknown_column").Scan(ctx, model)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Model does not have column")
+}
+
+func testSelectStructNilPtr(t *testing.T, db *bun.DB) {
+	type Model struct {
+		Num int
+		Str string
+	}
+
+	// Scan a row into a nil **Model: the inner pointer should be allocated and populated.
+	var model *Model
+	err := db.NewSelect().
+		ColumnExpr("10 AS num, 'hello' AS str").
+		Scan(ctx, &model)
+	require.NoError(t, err)
+	require.NotNil(t, model)
+	require.Equal(t, 10, model.Num)
+	require.Equal(t, "hello", model.Str)
+
+	// No rows + nil **Model: should NOT return ErrNoRows; inner pointer stays nil.
+	var empty *Model
+	err = db.NewSelect().
+		TableExpr("(SELECT 42 AS num) AS t").
+		Where("1 = 2").
+		Scan(ctx, &empty)
+	require.NoError(t, err)
+	require.Nil(t, empty)
+
+	// Regression: a non-nil *Model (existing behaviour) must still return ErrNoRows.
+	nonNil := new(Model)
+	err = db.NewSelect().
+		TableExpr("(SELECT 42 AS num) AS t").
+		Where("1 = 2").
+		Scan(ctx, nonNil)
+	require.Equal(t, sql.ErrNoRows, err)
+
+	// Scan a row into a non-nil **Model: the existing inner pointer is reused.
+	existing := &Model{}
+	preserved := existing
+	err = db.NewSelect().
+		ColumnExpr("7 AS num, 'world' AS str").
+		Scan(ctx, &existing)
+	require.NoError(t, err)
+	require.Same(t, preserved, existing)
+	require.Equal(t, 7, existing.Num)
+	require.Equal(t, "world", existing.Str)
 }
 
 func testSelectNestedStructValue(t *testing.T, db *bun.DB) {

--- a/model.go
+++ b/model.go
@@ -124,6 +124,10 @@ func _newModel(db *DB, dest any, scan bool) (Model, error) {
 		return newMapModel(db, mapPtr), nil
 	case reflect.Struct:
 		return newStructTableModelValue(db, dest, v), nil
+	case reflect.Pointer:
+		if v.Type().Elem().Kind() == reflect.Struct {
+			return newStructTableModelValue(db, dest, v), nil
+		}
 	case reflect.Slice:
 		switch elemType := sliceElemType(v); elemType.Kind() {
 		case reflect.Struct:
@@ -200,8 +204,7 @@ func validMap(typ reflect.Type) error {
 
 func isSingleRowModel(m Model) bool {
 	switch m.(type) {
-	case *mapModel,
-		*structTableModel,
+	case *structTableModel,
 		*scanModel:
 		return true
 	default:

--- a/model.go
+++ b/model.go
@@ -204,10 +204,17 @@ func validMap(typ reflect.Type) error {
 
 func isSingleRowModel(m Model) bool {
 	switch m.(type) {
-	case *structTableModel,
+	case *mapModel,
+		*structTableModel,
 		*scanModel:
 		return true
 	default:
 		return false
 	}
+}
+
+// nilModel is implemented by models whose destination may be a nil pointer
+// that should not be treated as "no rows" when an empty result is scanned.
+type nilModel interface {
+	isNil() bool
 }

--- a/model.go
+++ b/model.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"net"
+	"net/netip"
 	"reflect"
 	"time"
 
@@ -14,8 +16,12 @@ import (
 var errNilModel = errors.New("bun: Model(nil)")
 
 var (
-	timeType  = reflect.TypeFor[time.Time]()
-	bytesType = reflect.TypeFor[[]byte]()
+	timeType        = reflect.TypeFor[time.Time]()
+	bytesType       = reflect.TypeFor[[]byte]()
+	scannerType     = reflect.TypeFor[sql.Scanner]()
+	ipNetType       = reflect.TypeFor[net.IPNet]()
+	netipAddrType   = reflect.TypeFor[netip.Addr]()
+	netipPrefixType = reflect.TypeFor[netip.Prefix]()
 )
 
 // Model is implemented by all Bun models.
@@ -78,6 +84,20 @@ func newSingleModel(db *DB, dest any) (Model, error) {
 	return _newModel(db, dest, false)
 }
 
+// isSingleValueStruct
+func isSingleValueStruct(typ reflect.Type) bool {
+	if typ.Kind() != reflect.Struct {
+		return false
+	}
+	if typ == timeType ||
+		typ == ipNetType ||
+		typ == netipAddrType ||
+		typ == netipPrefixType {
+		return true
+	}
+	return reflect.PointerTo(typ).Implements(scannerType)
+}
+
 func _newModel(db *DB, dest any, scan bool) (Model, error) {
 	switch dest := dest.(type) {
 	case nil:
@@ -125,13 +145,14 @@ func _newModel(db *DB, dest any, scan bool) (Model, error) {
 	case reflect.Struct:
 		return newStructTableModelValue(db, dest, v), nil
 	case reflect.Pointer:
-		if v.Type().Elem().Kind() == reflect.Struct {
+		elemType := v.Type().Elem()
+		if elemType.Kind() == reflect.Struct && !isSingleValueStruct(elemType) {
 			return newStructTableModelValue(db, dest, v), nil
 		}
 	case reflect.Slice:
 		switch elemType := sliceElemType(v); elemType.Kind() {
 		case reflect.Struct:
-			if elemType != timeType {
+			if !isSingleValueStruct(elemType) {
 				return newSliceTableModel(db, dest, v, elemType), nil
 			}
 		case reflect.Map:

--- a/model_map.go
+++ b/model_map.go
@@ -39,6 +39,10 @@ func (m *mapModel) Value() any {
 	return m.dest
 }
 
+func (m *mapModel) isNil() bool {
+	return m.dest == nil || *m.dest == nil
+}
+
 func (m *mapModel) ScanRows(ctx context.Context, rows *sql.Rows) (int, error) {
 	if !rows.Next() {
 		return 0, rows.Err()

--- a/model_scan.go
+++ b/model_scan.go
@@ -28,6 +28,19 @@ func (m *scanModel) Value() any {
 	return m.dest
 }
 
+func (m *scanModel) isNil() bool {
+	if len(m.dest) == 0 {
+		return false
+	}
+	for _, item := range m.dest {
+		itemVal := reflect.ValueOf(item).Elem()
+		if isNil := itemVal.Type().Kind() == reflect.Pointer && itemVal.IsNil(); !isNil {
+			return false
+		}
+	}
+	return true
+}
+
 func (m *scanModel) ScanRows(ctx context.Context, rows *sql.Rows) (int, error) {
 	if !rows.Next() {
 		return 0, rows.Err()

--- a/query_base.go
+++ b/query_base.go
@@ -630,7 +630,7 @@ func (q *baseQuery) _scan(
 	}
 
 	if numRow == 0 && hasDest && isSingleRowModel(model) {
-		if nm, ok := model.(*structTableModel); ok && nm.isNil() {
+		if nm, ok := model.(nilModel); ok && nm.isNil() {
 			return driver.RowsAffected(numRow), nil
 		}
 		return nil, sql.ErrNoRows

--- a/query_base.go
+++ b/query_base.go
@@ -630,6 +630,9 @@ func (q *baseQuery) _scan(
 	}
 
 	if numRow == 0 && hasDest && isSingleRowModel(model) {
+		if nm, ok := model.(*structTableModel); ok && nm.isNil() {
+			return driver.RowsAffected(numRow), nil
+		}
 		return nil, sql.ErrNoRows
 	}
 	return driver.RowsAffected(numRow), nil


### PR DESCRIPTION
### previous writing styles
```
user := new(User)
err := db.NewSelect().Model(usert). Where("id = ?", 1).Scan(ctx)
// If there is no data that meets the criteria，err = sql.ErrNoRows， user != nil
```

###  new feature
```
var user *User
err := db.NewSelect().Model(&usert). Where("id = ?", 1).Scan(ctx)
If there is no data that meets the criteria，err = nil， user = nil

var users map[string]any
err := db.NewSelect().Model((*User)(nil)). Where("id = ?", 1).Scan(ctx, &users)
If there is no data that meets the criteria，err = nil， users = nil

var phone *string
err := db.NewSelect().Model((*User)(nil)). Where("id = ?", 1).Column("phone").Scan(ctx, &phone)
If there is no data that meets the criteria，err = nil， phone = nil
```
Compatible with previous writing styles
