### PR TITLE
fix: correct typos in code comments

### DIFF
--- a/dialect/pgdialect/sqltype.go
+++ b/dialect/pgdialect/sqltype.go
@@ -155,7 +155,7 @@ func (d *Dialect) CompareType(col1, col2 sqlschema.Column) bool {
 }
 
 // checkVarcharLen returns true if columns have the same VarcharLen, or,
-// if one specifies no VarcharLen and the other one has the default lenght for pgdialect.
+// if one specifies no VarcharLen and the other one has the default length for pgdialect.
 // We assume that the types are otherwise equivalent and that any non-character column
 // would have VarcharLen == 0;
 func checkVarcharLen(col1, col2 sqlschema.Column, defaultLen int) bool {

--- a/extra/bunexp/resolver.go
+++ b/extra/bunexp/resolver.go
@@ -26,7 +26,7 @@ var _ (bun.ConnResolver) = (*ReadWriteConnResolver)(nil)
 
 // TODO:
 //   - make monitoring interval configurable
-//   - make ping timeout configutable
+//   - make ping timeout configurable
 //   - allow adding read/write replicas for multi-master replication
 type ReadWriteConnResolver struct {
 	rw     replicas // for read-write queries

--- a/internal/dbtest/migrate_test.go
+++ b/internal/dbtest/migrate_test.go
@@ -363,12 +363,12 @@ func newAutoMigratorOrSkip(tb testing.TB, db *bun.DB, opts ...migrate.AutoMigrat
 }
 
 // inspectDbOrSkip returns a function to inspect the current state of the database.
-// The test will be *skipped* if the current dialect doesn't support database inpection
+// The test will be *skipped* if the current dialect doesn't support database inspection
 // and fail if the inspector cannot successfully retrieve database state.
 func inspectDbOrSkip(tb testing.TB, db *bun.DB, options ...sqlschema.InspectorOption) func(context.Context) sqlschema.BaseDatabase {
 	tb.Helper()
 
-	// By appending options to default options we make sure they can be overriden.
+	// By appending options to default options we make sure they can be overridden.
 	// E.g. passing sqlschema.WithSchemaName("custom") sets migration schema to "custom".
 	defaultOptions := []sqlschema.InspectorOption{
 		sqlschema.WithSchemaName(db.Dialect().DefaultSchema()),

--- a/migrate/auto.go
+++ b/migrate/auto.go
@@ -40,7 +40,7 @@ func WithExcludeTable(tables ...string) AutoMigratorOption {
 	}
 }
 
-// WithExcludeForeignKeys tells AutoMigrator to exclude a foreign key constaint
+// WithExcludeForeignKeys tells AutoMigrator to exclude a foreign key constraint
 // from the migration scope. This prevents AutoMigrator from dropping foreign keys
 // that are defined manually via CreateTableQuery.ForeignKey().
 func WithExcludeForeignKeys(fks ...sqlschema.ForeignKey) AutoMigratorOption {

--- a/migrate/operations.go
+++ b/migrate/operations.go
@@ -250,7 +250,7 @@ func (op *DropUniqueConstraintOp) GetReverse() Operation {
 
 // ChangeColumnTypeOp set a new data type for the column.
 // The two types should be such that the data can be auto-casted from one to another.
-// E.g. reducing VARCHAR lenght is not possible in most dialects.
+// E.g. reducing VARCHAR length is not possible in most dialects.
 // AutoMigrator does not enforce or validate these rules.
 type ChangeColumnTypeOp struct {
 	TableName string

--- a/migrate/sqlschema/database.go
+++ b/migrate/sqlschema/database.go
@@ -76,7 +76,7 @@ func (c *Columns) Split() []string {
 	return strings.Split(c.String(), ",")
 }
 
-// ContainsColumns checks that columns in "other" are a subset of current colums.
+// ContainsColumns checks that columns in "other" are a subset of current columns.
 func (c *Columns) ContainsColumns(other Columns) bool {
 	columns := c.Split()
 Outer:

--- a/migrate/sqlschema/inspector.go
+++ b/migrate/sqlschema/inspector.go
@@ -15,7 +15,7 @@ type InspectorDialect interface {
 
 	// Inspector returns a new instance of Inspector for the dialect.
 	// Dialects MAY set their default InspectorConfig values in constructor
-	// but MUST apply InspectorOptions to ensure they can be overriden.
+	// but MUST apply InspectorOptions to ensure they can be overridden.
 	//
 	// Use ApplyInspectorOptions to reduce boilerplate.
 	NewInspector(db *bun.DB, options ...InspectorOption) Inspector

--- a/migrate/sqlschema/migrator.go
+++ b/migrate/sqlschema/migrator.go
@@ -33,7 +33,7 @@ func NewMigrator(db *bun.DB, schemaName string) (Migrator, error) {
 	}, nil
 }
 
-// BaseMigrator can be embeded by dialect's Migrator implementations to re-use some of the existing bun queries.
+// BaseMigrator can be embedded by dialect's Migrator implementations to re-use some of the existing bun queries.
 type BaseMigrator struct {
 	db *bun.DB
 }


### PR DESCRIPTION
Fix several spelling mistakes in Go doc comments and inline comments.

Changes:
- `constaint` -> `constraint` in `migrate/auto.go`
- `lenght` -> `length` in `migrate/operations.go` and `dialect/pgdialect/sqltype.go`
- `colums` -> `columns` in `migrate/sqlschema/database.go`
- `overriden` -> `overridden` in `migrate/sqlschema/inspector.go` and `internal/dbtest/migrate_test.go`
- `embeded` -> `embedded` in `migrate/sqlschema/migrator.go`
- `configutable` -> `configurable` in `extra/bunexp/resolver.go`
- `inpection` -> `inspection` in `internal/dbtest/migrate_test.go`

All fixes are in comments only — no logic, API, or behavior is changed.