### PR TITLE
fix(migrate): surface lost SQL migration finalizer errors (#1389)

### DIFF
--- a/migrate/migration.go
+++ b/migrate/migration.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -67,7 +68,7 @@ func wrapGoMigrationFunc(fn MigrationFunc) internalMigrationFunc {
 }
 
 func newSQLMigrationFunc(fsys fs.FS, name string) internalMigrationFunc {
-	return func(ctx context.Context, migrator *Migrator, migration *Migration) error {
+	return func(ctx context.Context, migrator *Migrator, migration *Migration) (err error) {
 		sqlFile, err := fsys.Open(name)
 		if err != nil {
 			return err
@@ -137,21 +138,25 @@ func newSQLMigrationFunc(fsys fs.FS, name string) internalMigrationFunc {
 			idb = conn
 		}
 
-		var retErr error
 		var execErr error
 
 		defer func() {
+			// The migration body ran via a named return, so the finalizer's
+			// error can be reported back to Migrator.Migrate instead of being
+			// discarded (the previous unnamed return evaluated `return` before
+			// this deferred function assigned to it). When the body already
+			// failed, keep that error and preserve the finalizer error too.
 			if tx, ok := idb.(bun.Tx); ok {
 				if execErr != nil {
-					retErr = tx.Rollback()
+					err = errors.Join(execErr, tx.Rollback())
 				} else {
-					retErr = tx.Commit()
+					err = tx.Commit()
 				}
 				return
 			}
 
 			if conn, ok := idb.(bun.Conn); ok {
-				retErr = conn.Close()
+				err = errors.Join(execErr, conn.Close())
 				return
 			}
 
@@ -159,10 +164,7 @@ func newSQLMigrationFunc(fsys fs.FS, name string) internalMigrationFunc {
 		}()
 
 		execErr = migrator.exec(ctx, idb, migration, queries)
-		if execErr != nil {
-			return execErr
-		}
-		return retErr
+		return execErr
 	}
 }
 

--- a/migrate/migration_finalizer_test.go
+++ b/migrate/migration_finalizer_test.go
@@ -1,0 +1,148 @@
+package migrate
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"testing"
+	"testing/fstest"
+
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect"
+	"github.com/uptrace/bun/dialect/feature"
+	"github.com/uptrace/bun/schema"
+)
+
+// Regression test for https://github.com/uptrace/bun/issues/1389: SQL migration
+// finalizer errors (tx.Commit / tx.Rollback / conn.Close) were discarded
+// because the migration ran with an unnamed return.
+
+var (
+	errCommitFailed = errors.New("commit failed")
+	errExecFailed   = errors.New("exec failed")
+)
+
+// failingDriver is a database/sql driver whose transactions fail to commit, and
+// which optionally fails ExecContext, so we can observe how the migration func
+// reports finalizer errors.
+type failingDriver struct{ failExec bool }
+
+func (d failingDriver) Open(string) (driver.Conn, error) {
+	return failingConn(d), nil
+}
+
+type failingConn struct{ failExec bool }
+
+func (failingConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("prepare not supported")
+}
+func (failingConn) Close() error              { return nil }
+func (failingConn) Begin() (driver.Tx, error) { return failingTx{}, nil }
+func (failingConn) BeginTx(context.Context, driver.TxOptions) (driver.Tx, error) {
+	return failingTx{}, nil
+}
+
+func (c failingConn) ExecContext(
+	context.Context, string, []driver.NamedValue,
+) (driver.Result, error) {
+	if c.failExec {
+		return nil, errExecFailed
+	}
+	return driver.ResultNoRows, nil
+}
+
+func (failingConn) QueryContext(
+	context.Context, string, []driver.NamedValue,
+) (driver.Rows, error) {
+	return emptyRows{}, nil
+}
+
+type failingTx struct{}
+
+func (failingTx) Commit() error   { return errCommitFailed }
+func (failingTx) Rollback() error { return nil }
+
+type emptyRows struct{}
+
+func (emptyRows) Columns() []string              { return nil }
+func (emptyRows) Close() error                   { return nil }
+func (emptyRows) Next(dest []driver.Value) error { return io.EOF }
+
+func init() {
+	sql.Register("bun-migrate-failcommit", failingDriver{})
+	sql.Register("bun-migrate-failexec", failingDriver{failExec: true})
+}
+
+// testDialect is a minimal dialect (mirroring bun's internal nopDialect) so the
+// migrator can be constructed without pulling in a dialect module.
+type testDialect struct {
+	schema.BaseDialect
+	tables *schema.Tables
+}
+
+func newTestDialect() *testDialect {
+	d := new(testDialect)
+	d.tables = schema.NewTables(d)
+	return d
+}
+
+func (*testDialect) Init(*sql.DB)              {}
+func (*testDialect) Name() dialect.Name        { return dialect.SQLite }
+func (*testDialect) Features() feature.Feature { return 0 }
+func (d *testDialect) Tables() *schema.Tables  { return d.tables }
+func (*testDialect) OnField(*schema.Field)     {}
+func (*testDialect) OnTable(*schema.Table)     {}
+func (*testDialect) IdentQuote() byte          { return '"' }
+func (*testDialect) DefaultVarcharLen() int    { return 0 }
+func (*testDialect) DefaultSchema() string     { return "main" }
+func (*testDialect) AppendSequence([]byte, *schema.Table, *schema.Field) []byte {
+	return nil
+}
+
+func newTestMigrator(t *testing.T, driverName string) *Migrator {
+	t.Helper()
+
+	sqldb, err := sql.Open(driverName, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = sqldb.Close() })
+
+	db := bun.NewDB(sqldb, newTestDialect())
+	return NewMigrator(db, NewMigrations())
+}
+
+func runSQLMigration(t *testing.T, migrator *Migrator) error {
+	t.Helper()
+
+	const name = "20260101000000_test.tx.up.sql"
+	fsys := fstest.MapFS{
+		name: &fstest.MapFile{Data: []byte("SELECT 1;")},
+	}
+
+	fn := newSQLMigrationFunc(fsys, name)
+	return fn(context.Background(), migrator, &Migration{})
+}
+
+func TestSQLMigrationReturnsCommitError(t *testing.T) {
+	migrator := newTestMigrator(t, "bun-migrate-failcommit")
+
+	err := runSQLMigration(t, migrator)
+
+	if !errors.Is(err, errCommitFailed) {
+		t.Fatalf("expected the commit error to be returned, got: %v", err)
+	}
+}
+
+func TestSQLMigrationPreservesExecError(t *testing.T) {
+	migrator := newTestMigrator(t, "bun-migrate-failexec")
+
+	err := runSQLMigration(t, migrator)
+
+	// The execution error must still be reported when the body fails.
+	if !errors.Is(err, errExecFailed) {
+		t.Fatalf("expected the exec error to be returned, got: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #1389.

SQL migrations run via an unnamed return, so the finalizer's error (`tx.Commit` / `tx.Rollback` / `bun.Conn.Close`) was assigned to a local `retErr` inside the deferred function after `return` had already evaluated the result. In Go, the return expression is copied to the (unnamed) result before deferred functions run, so those finalizer errors were silently dropped:

- On a successful `.tx.up.sql`, a `Commit` error was lost. With `WithMarkAppliedOnSuccess(true)` the migrator could then mark the migration applied even though the commit's outcome was uncertain.
- On failure, the `Rollback` error was lost.
- For non-transactional SQL migrations, a `Conn.Close` error was lost.

This switches the migration closure to a named return and assigns the finalizer error to it. The execution error keeps priority: when the body fails, its error is preserved and joined with any rollback/close error via `errors.Join`.

Tests (`migrate/migration_finalizer_test.go`) use a small `database/sql` driver whose transactions fail to commit (and optionally fail exec):

- a `Commit` error is now returned from the migration (previously nil)
- an execution error is still returned when the body fails
