### PR TITLE
Add slice of byte array support to pgdialect

### DIFF
--- a/dialect/pgdialect/array.go
+++ b/dialect/pgdialect/array.go
@@ -149,7 +149,7 @@ func (d *Dialect) arrayElemAppender(typ reflect.Type) schema.AppenderFunc {
 	switch typ.Kind() {
 	case reflect.String:
 		return appendStringElemValue
-	case reflect.Slice:
+	case reflect.Slice, reflect.Array:
 		if typ.Elem().Kind() == reflect.Uint8 {
 			return appendBytesElemValue
 		}

--- a/dialect/pgdialect/array_test.go
+++ b/dialect/pgdialect/array_test.go
@@ -39,6 +39,14 @@ func TestArrayAppend(t *testing.T) {
 			input: []*string{ptr("foo"), ptr("bar")},
 			out:   `'{"foo","bar"}'`,
 		},
+		{
+			input: [][]byte{{1, 2, 3}, {4, 5, 6}},
+			out:   `'{"\\x010203","\\x040506"}'`,
+		},
+		{
+			input: [][3]byte{{1, 2, 3}, {4, 5, 6}},
+			out:   `'{"\\x010203","\\x040506"}'`,
+		},
 	}
 
 	for _, tcase := range tcases {


### PR DESCRIPTION
I need to store an array of [ULIDs](https://github.com/oklog/ulid) in a `bytea[]` field. pgdialect correctly identifies this type as an array of `[16]byte` but generates an invalid SQL literal due to single quotes within a single quoted string, eg `'{'\x010203','\x040506'}'`.

This is a very simple fix with unit tests.