### PR TITLE
fix: copy execution state in SelectQuery.Clone

### DIFF
--- a/query_select.go
+++ b/query_select.go
@@ -1193,6 +1193,14 @@ func (q *SelectQuery) Clone() *SelectQuery {
 		copy(clone, args)
 		return clone
 	}
+	cloneWhereFields := func(fields []*schema.Field) []*schema.Field {
+		if fields == nil {
+			return nil
+		}
+		clone := make([]*schema.Field, len(fields))
+		copy(clone, fields)
+		return clone
+	}
 	cloneHints := func(hints *indexHints) *indexHints {
 		if hints == nil {
 			return nil
@@ -1213,15 +1221,19 @@ func (q *SelectQuery) Clone() *SelectQuery {
 		whereBaseQuery: whereBaseQuery{
 			baseQuery: baseQuery{
 				db:             q.db,
+				conn:           q.conn,
 				table:          q.table,
 				model:          q.model,
+				err:            q.err,
 				tableModel:     tableModel,
 				with:           make([]WithQuery, len(q.with)),
 				tables:         cloneArgs(q.tables),
 				columns:        cloneArgs(q.columns),
 				modelTableName: q.modelTableName,
+				flags:          q.flags,
 			},
-			where: make([]schema.QueryWithSep, len(q.where)),
+			where:       make([]schema.QueryWithSep, len(q.where)),
+			whereFields: cloneWhereFields(q.whereFields),
 		},
 
 		idxHintsQuery: idxHintsQuery{
@@ -1246,9 +1258,11 @@ func (q *SelectQuery) Clone() *SelectQuery {
 
 	for i, w := range q.with {
 		clone.with[i] = WithQuery{
-			name:      w.name,
-			recursive: w.recursive,
-			query:     w.query, // TODO: maybe clone is need
+			name:            w.name,
+			recursive:       w.recursive,
+			materialized:    w.materialized,
+			notMaterialized: w.notMaterialized,
+			query:           w.query, // TODO: maybe clone is need
 		}
 	}
 

--- a/query_select_clone_test.go
+++ b/query_select_clone_test.go
@@ -1,0 +1,49 @@
+package bun
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/uptrace/bun/schema"
+)
+
+// Regression test for #1388: Clone must copy execution state, not only the
+// public builder slices.
+func TestSelectQueryCloneCopiesExecutionState(t *testing.T) {
+	sentinelErr := errors.New("sentinel")
+	conn := &DB{}
+	pk := &schema.Field{Name: "id"}
+
+	q := &SelectQuery{}
+	q.conn = conn
+	q.err = sentinelErr
+	q.flags = q.flags.Set(deletedFlag)
+	q.whereFields = []*schema.Field{pk}
+	q.with = []WithQuery{
+		{name: "mat", materialized: true},
+		{name: "not_mat", notMaterialized: true},
+	}
+
+	clone := q.Clone()
+
+	require.True(t, clone.conn == IConn(conn), "conn must be copied")
+	require.True(t, clone.err == sentinelErr, "err must be copied")
+	require.True(t, clone.flags.Has(deletedFlag), "flags must be copied")
+	require.Equal(t, []*schema.Field{pk}, clone.whereFields)
+	require.True(t, clone.with[0].materialized, "materialized must be copied")
+	require.True(t, clone.with[1].notMaterialized, "notMaterialized must be copied")
+
+	// The whereFields slice must be a copy, not an alias.
+	clone.whereFields[0] = &schema.Field{Name: "other"}
+	require.True(t, q.whereFields[0] == pk, "whereFields must not alias the original")
+}
+
+func TestSelectQueryCloneNilWhereFields(t *testing.T) {
+	q := &SelectQuery{}
+	require.Nil(t, q.Clone().whereFields)
+
+	var nilQuery *SelectQuery
+	require.Nil(t, nilQuery.Clone())
+}


### PR DESCRIPTION
Closes #1388

`SelectQuery.Clone` copies the builder slices but leaves several execution-affecting fields at their zero values:

- `baseQuery.conn`: the clone targets the default pool, not the original's transaction or connection.
- `baseQuery.err`: a recorded builder error is dropped, so the clone runs instead of returning it.
- `baseQuery.flags`: `WhereDeleted` / `WhereAllWithDeleted` are lost.
- `whereBaseQuery.whereFields`: `WherePK` becomes an unfiltered scan.
- `WithQuery.materialized` / `notMaterialized`: `MATERIALIZED` hints disappear from the CTE.

I copy these fields, including the two `WithQuery` hints. `whereFields` goes through the same nil check `cloneArgs` uses, so a non-nil empty slice survives and a nil one stays nil.

The execution-state test fails on master and passes here. `go test ./...` passes in the root module.