### PR TITLE
fix: return an error instead of panicking when scanning JSON into an unaddressable value

### DIFF
--- a/schema/scan.go
+++ b/schema/scan.go
@@ -352,6 +352,9 @@ func scanJSON(dest reflect.Value, src any) error {
 	if src == nil {
 		return scanNull(dest)
 	}
+	if !dest.CanAddr() {
+		return fmt.Errorf("bun: Scan(nonaddressable %s)", dest.Type())
+	}
 
 	b, err := toBytes(src)
 	if err != nil {
@@ -364,6 +367,9 @@ func scanJSON(dest reflect.Value, src any) error {
 func scanJSONUseNumber(dest reflect.Value, src any) error {
 	if src == nil {
 		return scanNull(dest)
+	}
+	if !dest.CanAddr() {
+		return fmt.Errorf("bun: Scan(nonaddressable %s)", dest.Type())
 	}
 
 	b, err := toBytes(src)
@@ -531,6 +537,9 @@ func scanJSONIntoInterface(dest reflect.Value, src any) error {
 	}
 
 	dest = dest.Elem()
+	if !dest.CanAddr() {
+		return fmt.Errorf("bun: Scan(nonaddressable %s)", dest.Type())
+	}
 	if fn := Scanner(dest.Type()); fn != nil {
 		return fn(dest, src)
 	}

--- a/schema/scan.go
+++ b/schema/scan.go
@@ -537,9 +537,6 @@ func scanJSONIntoInterface(dest reflect.Value, src any) error {
 	}
 
 	dest = dest.Elem()
-	if !dest.CanAddr() {
-		return fmt.Errorf("bun: Scan(nonaddressable %s)", dest.Type())
-	}
 	if fn := Scanner(dest.Type()); fn != nil {
 		return fn(dest, src)
 	}

--- a/schema/scan.go
+++ b/schema/scan.go
@@ -518,6 +518,9 @@ func scanNull(dest reflect.Value) error {
 	if nilable(dest.Kind()) && dest.IsNil() {
 		return nil
 	}
+	if !dest.CanAddr() {
+		return fmt.Errorf("bun: Scan(nonaddressable %s)", dest.Type())
+	}
 	dest.Set(reflect.New(dest.Type()).Elem())
 	return nil
 }

--- a/schema/scan_json_test.go
+++ b/schema/scan_json_test.go
@@ -1,0 +1,36 @@
+package schema
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Regression test for #1306: scanning JSON into a non-nil interface used to
+// panic on dest.Addr() because the interface element is not addressable. The
+// scan must fail with an error instead, so the query does not deadlock.
+func TestScanJSONUnaddressableInterface(t *testing.T) {
+	var value any = map[string]any{"a": float64(1)}
+	dest := reflect.ValueOf(&value).Elem()
+
+	fn := Scanner(dest.Type())
+	require.NotNil(t, fn)
+
+	require.NotPanics(t, func() {
+		err := fn(dest, []byte(`{"b":2}`))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "nonaddressable")
+	})
+}
+
+func TestScanJSONAddressableMap(t *testing.T) {
+	var value map[string]any
+	dest := reflect.ValueOf(&value).Elem()
+
+	fn := Scanner(dest.Type())
+	require.NotNil(t, fn)
+
+	require.NoError(t, fn(dest, []byte(`{"b":2}`)))
+	require.Equal(t, map[string]any{"b": float64(2)}, value)
+}

--- a/schema/scan_json_test.go
+++ b/schema/scan_json_test.go
@@ -7,6 +7,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type jsonPayload struct {
+	A int `json:"a"`
+}
+
+type jsonRawScanner struct {
+	raw string
+}
+
+func (s *jsonRawScanner) Scan(src any) error {
+	b, err := toBytes(src)
+	if err != nil {
+		return err
+	}
+	s.raw = string(b)
+	return nil
+}
+
 // Regression test for #1306: scanning JSON into a non-nil interface used to
 // panic on dest.Addr() because the interface element is not addressable. The
 // scan must fail with an error instead, so the query does not deadlock.
@@ -14,14 +31,49 @@ func TestScanJSONUnaddressableInterface(t *testing.T) {
 	var value any = map[string]any{"a": float64(1)}
 	dest := reflect.ValueOf(&value).Elem()
 
-	fn := Scanner(dest.Type())
-	require.NotNil(t, fn)
-
+	var err error
 	require.NotPanics(t, func() {
-		err := fn(dest, []byte(`{"b":2}`))
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "nonaddressable")
+		err = scanJSONIntoInterface(dest, []byte(`{"b":2}`))
 	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nonaddressable")
+}
+
+// json_use_number fields scan through scanJSONUseNumber, which calls
+// dest.Addr() as well.
+func TestScanJSONUseNumberUnaddressable(t *testing.T) {
+	var value any = map[string]any{"a": float64(1)}
+	dest := reflect.ValueOf(&value).Elem().Elem()
+
+	var err error
+	require.NotPanics(t, func() {
+		err = scanJSONUseNumber(dest, []byte(`{"b":2}`))
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nonaddressable")
+}
+
+// A pointer stored in an interface is not addressable either, but PtrScanner
+// scans into the pointer's element, which is. Such values scanned before the
+// fix and must keep scanning.
+func TestScanJSONPointerInInterface(t *testing.T) {
+	payload := &jsonPayload{}
+	var value any = payload
+	dest := reflect.ValueOf(&value).Elem()
+
+	require.NoError(t, scanJSONIntoInterface(dest, []byte(`{"a":7}`)))
+	require.Equal(t, 7, payload.A)
+}
+
+// A pointer type implementing sql.Scanner reaches its Scan method through
+// PtrScanner as well.
+func TestScanJSONScannerInInterface(t *testing.T) {
+	scanner := &jsonRawScanner{}
+	var value any = scanner
+	dest := reflect.ValueOf(&value).Elem()
+
+	require.NoError(t, scanJSONIntoInterface(dest, []byte(`{"a":7}`)))
+	require.Equal(t, `{"a":7}`, scanner.raw)
 }
 
 func TestScanJSONAddressableMap(t *testing.T) {

--- a/schema/scan_json_test.go
+++ b/schema/scan_json_test.go
@@ -39,6 +39,34 @@ func TestScanJSONUnaddressableInterface(t *testing.T) {
 	require.Contains(t, err.Error(), "nonaddressable")
 }
 
+func TestScanJSONIntoInterfaceNonAddressableNil(t *testing.T) {
+	var value any = map[string]any{"a": 1}
+	dest := reflect.ValueOf(&value).Elem()
+
+	require.NotPanics(t, func() {
+		err := scanJSONIntoInterface(dest, nil)
+		require.Error(t, err)
+	})
+}
+
+// Scanning NULL zeroes an addressable dest.
+func TestScanJSONAddressableNull(t *testing.T) {
+	value := map[string]any{"a": float64(1)}
+	dest := reflect.ValueOf(&value).Elem()
+
+	require.NoError(t, scanJSON(dest, nil))
+	require.Nil(t, value)
+}
+
+// A typed nil map inside an interface is already zero, so scanning NULL
+// into it stays a no-op.
+func TestScanJSONIntoInterfaceNilMapNull(t *testing.T) {
+	var value any = map[string]any(nil)
+	dest := reflect.ValueOf(&value).Elem()
+
+	require.NoError(t, scanJSONIntoInterface(dest, nil))
+}
+
 // json_use_number fields scan through scanJSONUseNumber, which calls
 // dest.Addr() as well.
 func TestScanJSONUseNumberUnaddressable(t *testing.T) {


### PR DESCRIPTION
Scanning a JSONB column into a non-nil interface field routes through `scanJSONIntoInterface`, where `scanJSON` panicked on `dest.Addr()` because the interface element is not addressable, leaving the connection idle in transaction and the query blocked.

The check now sits in `scanJSON` and `scanJSONUseNumber`, the two scanners that call `dest.Addr()`, and in `scanNull`, which reached `dest.Set` on the same unaddressable element when the column was NULL. A dest that is already nil keeps scanning NULL as a no-op. Values that are unaddressable but still scannable, such as a pointer stored in an interface, keep dispatching to `PtrScanner`.

Fixes #1306
