### PR TITLE
fix(schema): prevent line-comment SQL injection with negative numbers (CVE-2024-44906 class)

### DIFF
--- a/schema/append_value.go
+++ b/schema/append_value.go
@@ -187,7 +187,7 @@ func AppendBoolValue(gen QueryGen, b []byte, v reflect.Value) []byte {
 }
 
 func AppendIntValue(gen QueryGen, b []byte, v reflect.Value) []byte {
-	return strconv.AppendInt(b, v.Int(), 10)
+	return strconv.AppendInt(guardLineComment(b, v.Int() < 0), v.Int(), 10)
 }
 
 func AppendUintValue(gen QueryGen, b []byte, v reflect.Value) []byte {
@@ -203,11 +203,11 @@ func appendUint64Value(gen QueryGen, b []byte, v reflect.Value) []byte {
 }
 
 func AppendFloat32Value(gen QueryGen, b []byte, v reflect.Value) []byte {
-	return dialect.AppendFloat32(b, float32(v.Float()))
+	return dialect.AppendFloat32(guardLineComment(b, v.Float() < 0), float32(v.Float()))
 }
 
 func AppendFloat64Value(gen QueryGen, b []byte, v reflect.Value) []byte {
-	return dialect.AppendFloat64(b, float64(v.Float()))
+	return dialect.AppendFloat64(guardLineComment(b, v.Float() < 0), float64(v.Float()))
 }
 
 func appendBytesValue(gen QueryGen, b []byte, v reflect.Value) []byte {

--- a/schema/querygen.go
+++ b/schema/querygen.go
@@ -43,6 +43,18 @@ func (f QueryGen) IdentQuote() byte {
 	return f.dialect.IdentQuote()
 }
 
+// guardLineComment inserts a space when a negative numeric literal is about to
+// be appended immediately after a '-'. Without it, formatting an expression
+// such as "col - ?" with a negative argument produces "col --1", where the "--"
+// starts a SQL line comment that can be abused for SQL injection. This mirrors
+// the fix applied to driver/pgdriver (CVE-2024-44906).
+func guardLineComment(b []byte, negative bool) []byte {
+	if negative && len(b) > 0 && b[len(b)-1] == '-' {
+		return append(b, ' ')
+	}
+	return b
+}
+
 func (gen QueryGen) Append(b []byte, v any) []byte {
 	switch v := v.(type) {
 	case nil:
@@ -50,11 +62,11 @@ func (gen QueryGen) Append(b []byte, v any) []byte {
 	case bool:
 		return gen.Dialect().AppendBool(b, v)
 	case int:
-		return strconv.AppendInt(b, int64(v), 10)
+		return strconv.AppendInt(guardLineComment(b, v < 0), int64(v), 10)
 	case int32:
-		return strconv.AppendInt(b, int64(v), 10)
+		return strconv.AppendInt(guardLineComment(b, v < 0), int64(v), 10)
 	case int64:
-		return strconv.AppendInt(b, v, 10)
+		return strconv.AppendInt(guardLineComment(b, v < 0), v, 10)
 	case uint:
 		return strconv.AppendInt(b, int64(v), 10)
 	case uint32:
@@ -62,9 +74,9 @@ func (gen QueryGen) Append(b []byte, v any) []byte {
 	case uint64:
 		return gen.Dialect().AppendUint64(b, v)
 	case float32:
-		return dialect.AppendFloat32(b, v)
+		return dialect.AppendFloat32(guardLineComment(b, v < 0), v)
 	case float64:
-		return dialect.AppendFloat64(b, v)
+		return dialect.AppendFloat64(guardLineComment(b, v < 0), v)
 	case string:
 		return gen.Dialect().AppendString(b, v)
 	case time.Time:

--- a/schema/querygen_linecomment_test.go
+++ b/schema/querygen_linecomment_test.go
@@ -1,33 +1,48 @@
 package schema
 
 import (
-	"strings"
 	"testing"
+
+	"github.com/uptrace/bun/dialect"
 )
 
+// lcTestDialect is a non-nop dialect (so FormatQuery actually substitutes args)
+// that reuses nopDialect's BaseDialect-backed Append* implementations.
+type lcTestDialect struct {
+	*nopDialect
+}
+
+func (lcTestDialect) Name() dialect.Name { return dialect.PG }
+
 // Regression test for the line-comment SQL injection class (CVE-2024-44906):
-// a negative numeric argument that immediately follows a '-' must not produce
-// a "--" sequence, which PostgreSQL would parse as the start of a line comment.
+// a negative numeric argument that immediately follows a '-' must not produce a
+// "--" sequence, which PostgreSQL would parse as the start of a line comment. A
+// space is inserted so e.g. "1000-?" with -500 renders as "1000- -500".
 func TestQueryGen_Append_NegativeNumberDoesNotCreateLineComment(t *testing.T) {
-	gen := nopQueryGen
+	gen := NewQueryGen(lcTestDialect{newNopDialect()})
 
 	tests := []struct {
 		name string
 		expr string
 		arg  any
+		want string
 	}{
-		{"int", "1000-?", int(-500)},
-		{"int32", "1000-?", int32(-500)},
-		{"int64", "1000-?", int64(-500)},
-		{"float32", "1000-?", float32(-1.5)},
-		{"float64", "1000-?", float64(-1.5)},
+		{"int", "1000-?", int(-500), "1000- -500"},
+		{"int32", "1000-?", int32(-500), "1000- -500"},
+		{"int64", "1000-?", int64(-500), "1000- -500"},
+		{"float32", "1000-?", float32(-1.5), "1000- -1.5"},
+		{"float64", "1000-?", float64(-1.5), "1000- -1.5"},
+		// non-adjacent minus is unaffected (no spurious space).
+		{"spaced", "1000 - ?", int(-500), "1000 - -500"},
+		// positive values are unaffected.
+		{"positive", "1000-?", int(500), "1000-500"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b := gen.FormatQuery(tt.expr, tt.arg)
-			if strings.Contains(b, "--") {
-				t.Fatalf("formatted query contains a line comment %q for arg %v (%T)", b, tt.arg, tt.arg)
+			got := gen.FormatQuery(tt.expr, tt.arg)
+			if got != tt.want {
+				t.Fatalf("FormatQuery(%q, %v[%T]) = %q, want %q", tt.expr, tt.arg, tt.arg, got, tt.want)
 			}
 		})
 	}

--- a/schema/querygen_linecomment_test.go
+++ b/schema/querygen_linecomment_test.go
@@ -1,0 +1,34 @@
+package schema
+
+import (
+	"strings"
+	"testing"
+)
+
+// Regression test for the line-comment SQL injection class (CVE-2024-44906):
+// a negative numeric argument that immediately follows a '-' must not produce
+// a "--" sequence, which PostgreSQL would parse as the start of a line comment.
+func TestQueryGen_Append_NegativeNumberDoesNotCreateLineComment(t *testing.T) {
+	gen := nopQueryGen
+
+	tests := []struct {
+		name string
+		expr string
+		arg  any
+	}{
+		{"int", "1000-?", int(-500)},
+		{"int32", "1000-?", int32(-500)},
+		{"int64", "1000-?", int64(-500)},
+		{"float32", "1000-?", float32(-1.5)},
+		{"float64", "1000-?", float64(-1.5)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := gen.FormatQuery(tt.expr, tt.arg)
+			if strings.Contains(b, "--") {
+				t.Fatalf("formatted query contains a line comment %q for arg %v (%T)", b, tt.arg, tt.arg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Fixes a line-comment SQL injection in the query builder / `schema` formatter — the same class as **CVE-2024-44906**, whose fix landed in `driver/pgdriver` but was never applied to the `schema` formatter that powers `ColumnExpr`, `NewRaw`, `Where("… = ?", x)`, and reflected model values.

Closes #1395.

## Why

The `schema` formatter inlines numeric arguments as bare literals. A negative number formatted immediately after a `-` yields `--`, which PostgreSQL parses as a line comment. A later string argument containing a newline can then break out of the comment and inject SQL.

Reproduction on `master` / v1.2.18 (any driver — pgdriver, pgx, lib/pq):

```go
payload := "foo\n 1 AND 1=0 UNION SELECT name FROM secrets; --"
var names []string
db.NewRaw("SELECT name FROM example WHERE result=-? OR name=?", -42, payload).Scan(ctx, &names)
// names == ["TOPSECRET"]   <- data exfiltrated
```

SQL sent to the server:

```
SELECT name FROM example WHERE result=--42 OR name='foo
 1 AND 1=0 UNION SELECT name FROM secrets; --'
```

`--42` comments out the intended predicate; the newline in the (correctly quoted) string argument resumes on a new line and runs the injected `UNION`.

## Fix

Mirror the `driver/pgdriver.appendArg` guard: insert a space before a negative numeric literal when the preceding byte is `-`, so `1000-?` with `-500` formats as `1000- -500` instead of `1000--500`.

Applied in:
- `schema/querygen.go` — `QueryGen.Append` (`int`, `int32`, `int64`, `float32`, `float64`); `uint*` types are unsigned and left unchanged.
- `schema/append_value.go` — the reflected `AppendIntValue`, `AppendFloat32Value`, `AppendFloat64Value`.

A single helper `guardLineComment(b, negative)` is added next to `Append`.

## Tests

New driver-independent regression test `schema/querygen_linecomment_test.go` asserts that formatting `1000-?` with negative `int`/`int32`/`int64`/`float32`/`float64` never contains `--`. `go test ./schema/...`, `go vet ./schema/...`, and `gofmt` are clean.

## References

- CVE-2024-44906 / GHSA-h4h6-vccr-44h2 (pgdriver fix this ports)
- CVE-2024-27289 / GHSA-m7wr-2xf7-cm9p (pgx, same class)
- https://www.sonarsource.com/blog/double-dash-double-trouble-a-subtle-sql-injection-flaw/
