### PR TITLE
fix(schema): make the ? placeholder parser skip string literals and comments

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -110,6 +110,100 @@ func (p *Parser) ReadSep(sep byte) ([]byte, bool) {
 	return b, true
 }
 
+// ReadUntilPlaceholder reads up to the next '?' placeholder that is NOT inside a
+// single-quoted string literal or a "--" / "/* */" comment, returning the text
+// before it. The bool reports whether a placeholder was found (and, if so,
+// consumed). It is the literal/comment-aware counterpart of ReadSep('?').
+//
+// This prevents a '?' that appears inside a string literal or comment in the
+// query template from being mistaken for a bind placeholder, which would shift
+// every subsequent positional argument.
+//
+// Double-quoted identifiers are intentionally NOT skipped: bun uses named
+// placeholders inside quoted identifiers (e.g. multi-tenant "?tenant".table via
+// WithNamedArg), so a '?' there must still be treated as a placeholder.
+//
+// Scope/limitations (intentional, to avoid ever skipping a real placeholder):
+//   - Backslash escaping inside string literals is NOT interpreted. This matches
+//     PostgreSQL with standard_conforming_strings=on (the default since 9.1),
+//     where '\' is an ordinary character.
+//   - Dollar-quoted strings ($tag$...$tag$) and escape strings (E'...') are not
+//     specially tracked.
+//
+// In those unhandled cases the behaviour degrades to the previous (ReadSep)
+// behaviour rather than skipping a genuine placeholder.
+func (p *Parser) ReadUntilPlaceholder() ([]byte, bool) {
+	b := p.b
+	start := p.i
+	i := p.i
+	for i < len(b) {
+		switch b[i] {
+		case '?':
+			p.i = i + 1
+			return b[start:i], true
+		case '\'':
+			i = skipQuoted(b, i, '\'')
+		case '-':
+			if i+1 < len(b) && b[i+1] == '-' {
+				i += 2
+				for i < len(b) && b[i] != '\n' {
+					i++
+				}
+			} else {
+				i++
+			}
+		case '/':
+			if i+1 < len(b) && b[i+1] == '*' {
+				i = skipBlockComment(b, i)
+			} else {
+				i++
+			}
+		default:
+			i++
+		}
+	}
+	p.i = len(b)
+	return b[start:], false
+}
+
+// skipQuoted returns the index just past a string literal that starts at
+// b[i]==quote. A doubled quote (”) is treated as an escaped quote and does not
+// terminate the literal. If the literal is unterminated, the end of input is
+// returned.
+func skipQuoted(b []byte, i int, quote byte) int {
+	i++ // opening quote
+	for i < len(b) {
+		if b[i] == quote {
+			if i+1 < len(b) && b[i+1] == quote {
+				i += 2
+				continue
+			}
+			return i + 1
+		}
+		i++
+	}
+	return i
+}
+
+// skipBlockComment returns the index just past a /* */ comment that starts at
+// b[i:]=="/*". Block comments nest, matching PostgreSQL.
+func skipBlockComment(b []byte, i int) int {
+	i += 2
+	depth := 1
+	for i < len(b) && depth > 0 {
+		if b[i] == '/' && i+1 < len(b) && b[i+1] == '*' {
+			depth++
+			i += 2
+		} else if b[i] == '*' && i+1 < len(b) && b[i+1] == '/' {
+			depth--
+			i += 2
+		} else {
+			i++
+		}
+	}
+	return i
+}
+
 func (p *Parser) ReadIdentifier() (string, bool) {
 	if p.i < len(p.b) && p.b[p.i] == '(' {
 		s := p.i + 1

--- a/internal/parser/placeholder_test.go
+++ b/internal/parser/placeholder_test.go
@@ -1,0 +1,42 @@
+package parser
+
+import "testing"
+
+func TestReadUntilPlaceholder(t *testing.T) {
+	tests := []struct {
+		query   string
+		want    string // text before the first real placeholder
+		wantOk  bool
+		wantRem string // remaining after the consumed '?'
+	}{
+		{"a = ?", "a = ", true, ""},
+		{"no placeholder", "no placeholder", false, ""},
+		// '?' inside a single-quoted literal must be ignored.
+		{"'why?' , ?", "'why?' , ", true, ""},
+		{"note='huh?' AND id=?", "note='huh?' AND id=", true, ""},
+		// doubled quote stays inside the literal.
+		{"'it''s ?' , ?", "'it''s ?' , ", true, ""},
+		// Double-quoted identifiers are intentionally NOT skipped: a '?' inside
+		// them is a named placeholder (e.g. multi-tenant "?tenant".table).
+		{`"?tenant".t = ?`, `"`, true, `tenant".t = ?`},
+		// line comment.
+		{"1 -- really?\n, ?", "1 -- really?\n, ", true, ""},
+		// block comment (and nested).
+		{"1 /* huh? */, ?", "1 /* huh? */, ", true, ""},
+		{"1 /* a /* ? */ ? */, ?", "1 /* a /* ? */ ? */, ", true, ""},
+		// real placeholder before any literal is still found first.
+		{"? AND 'x?'", "", true, " AND 'x?'"},
+	}
+
+	for _, tt := range tests {
+		p := NewString(tt.query)
+		got, ok := p.ReadUntilPlaceholder()
+		if string(got) != tt.want || ok != tt.wantOk {
+			t.Errorf("ReadUntilPlaceholder(%q) = (%q, %v), want (%q, %v)",
+				tt.query, got, ok, tt.want, tt.wantOk)
+		}
+		if rem := string(p.Remaining()); rem != tt.wantRem {
+			t.Errorf("ReadUntilPlaceholder(%q) remaining = %q, want %q", tt.query, rem, tt.wantRem)
+		}
+	}
+}

--- a/schema/placeholder_literal_test.go
+++ b/schema/placeholder_literal_test.go
@@ -1,0 +1,67 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/uptrace/bun/dialect"
+)
+
+// testDialect is a non-nop dialect (so FormatQuery actually substitutes args)
+// that reuses nopDialect's BaseDialect-backed Append* implementations.
+type testDialect struct {
+	*nopDialect
+}
+
+func (testDialect) Name() dialect.Name { return dialect.PG }
+
+func newTestQueryGen() QueryGen {
+	return NewQueryGen(testDialect{newNopDialect()})
+}
+
+// Regression test: a '?' inside a string literal or comment in the query template
+// must not be treated as a bind placeholder (which used to shift every subsequent
+// positional argument).
+func TestFormatQuery_PlaceholderInsideLiteralOrComment(t *testing.T) {
+	gen := newTestQueryGen()
+
+	tests := []struct {
+		query string
+		args  []any
+		want  string
+	}{
+		// '?' inside a literal is left intact; the real placeholders bind correctly.
+		{
+			`note='huh?' AND org_id=? AND secret=?`,
+			[]any{42, 99},
+			`note='huh?' AND org_id=42 AND secret=99`,
+		},
+		{`'why?' , ?`, []any{7}, `'why?' , 7`},
+		// doubled quote inside the literal.
+		{`'it''s ?' , ?`, []any{5}, `'it''s ?' , 5`},
+		// line and block comments.
+		{"x=? -- really?\n", []any{1}, "x=1 -- really?\n"},
+		{`x=? /* huh? */`, []any{2}, `x=2 /* huh? */`},
+		// no false positives: normal placeholders still work.
+		{`a=? AND b=?`, []any{1, 2}, `a=1 AND b=2`},
+	}
+
+	for _, tt := range tests {
+		got := gen.FormatQuery(tt.query, tt.args...)
+		if got != tt.want {
+			t.Errorf("FormatQuery(%q, %v) = %q, want %q", tt.query, tt.args, got, tt.want)
+		}
+	}
+}
+
+// A named placeholder inside a double-quoted identifier must still be
+// substituted (bun's multi-tenant pattern: "?tenant".table via WithNamedArg).
+// Double-quoted identifiers must NOT be treated like string literals.
+func TestFormatQuery_NamedPlaceholderInQuotedIdentifier(t *testing.T) {
+	gen := newTestQueryGen().WithNamedArg("tenant", Safe("public"))
+
+	got := gen.FormatQuery(`"?tenant".recipes`)
+	want := `"public".recipes`
+	if got != want {
+		t.Fatalf("FormatQuery(%q) = %q, want %q", `"?tenant".recipes`, got, want)
+	}
+}

--- a/schema/querygen.go
+++ b/schema/querygen.go
@@ -143,7 +143,7 @@ func (f QueryGen) append(dst []byte, p *parser.Parser, args []any) []byte {
 
 	var argIndex int
 	for p.Valid() {
-		b, ok := p.ReadSep('?')
+		b, ok := p.ReadUntilPlaceholder()
 		if !ok {
 			dst = append(dst, b...)
 			continue


### PR DESCRIPTION
## What

Makes the query placeholder parser aware of string literals and comments, so a `?`
inside a `'...'`/`"..."` literal or a `--` / `/* */` comment is no longer mistaken for a
bind placeholder.

Closes #1399.

## Why

The formatter scanned for `?` with a plain byte search (`ReadSep('?')`), so a `?` in a
literal or comment consumed a positional argument and shifted every subsequent binding:

```go
db.NewRaw(`... WHERE note='huh?' AND org_id=? AND secret=?`, 42, "s3cr3t")
// before: ... WHERE note='huh42' AND org_id='s3cr3t' AND secret=?
//   -> org_id gets the wrong value; secret=? dangles (invalid SQL)
// after:  ... WHERE note='huh?'  AND org_id=42        AND secret='s3cr3t'
```

## Change

- Add `Parser.ReadUntilPlaceholder` (internal/parser): a literal/comment-aware
  replacement for `ReadSep('?')`. It skips `'...'`/`"..."` quoted strings (with doubled-quote
  escaping), `--` line comments, and nesting `/* */` block comments.
- `schema/querygen.go`: use `ReadUntilPlaceholder()` instead of `ReadSep('?')` (one line).

The scanner is deliberately conservative so it can **never skip a genuine placeholder**:
backslash escaping inside literals is not interpreted (matches
`standard_conforming_strings=on`, the default since PG 9.1), and `$$...$$` / `E'...'` strings
degrade to the previous behavior rather than over-consuming. The existing `\?` escape and
named/positional argument handling are unchanged.

## Tests

- `internal/parser`: unit tests for `ReadUntilPlaceholder` (literals, doubled quotes,
  quoted identifiers, line/nested-block comments, placeholder-before-literal).
- `schema`: formatter-level regression test asserting exact output; it fails on the old
  `ReadSep` behavior and passes with the fix. Full `go test ./internal/... ./schema/... .`
  passes; `gofmt`/`go vet` clean.
