### PR TITLE
fix(pgdriver): verify server certificate for WithInsecure(false)

### DIFF
--- a/driver/pgdriver/config.go
+++ b/driver/pgdriver/config.go
@@ -128,14 +128,34 @@ func WithTLSConfig(tlsConfig *tls.Config) Option {
 	}
 }
 
+// WithInsecure configures how the connection is protected.
+//
+//   - WithInsecure(true) disables TLS entirely (plaintext connection).
+//   - WithInsecure(false) enables TLS *with* server-certificate verification.
+//     ServerName is derived from the connection address at connect time.
+//
+// Note: previously WithInsecure(false) enabled TLS but skipped certificate
+// verification (InsecureSkipVerify: true), which left the connection open to
+// active man-in-the-middle attacks. To intentionally skip verification (e.g. a
+// self-signed certificate in development) pass an explicit config via
+// WithTLSConfig(&tls.Config{InsecureSkipVerify: true}).
 func WithInsecure(on bool) Option {
 	return func(conf *Config) {
 		if on {
 			conf.TLSConfig = nil
 		} else {
-			conf.TLSConfig = &tls.Config{InsecureSkipVerify: true}
+			conf.TLSConfig = &tls.Config{}
 		}
 	}
+}
+
+// hostWithoutPort returns the host portion of a "host:port" address, or the
+// address unchanged if it has no port.
+func hostWithoutPort(addr string) string {
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		return host
+	}
+	return addr
 }
 
 func WithUser(user string) Option {

--- a/driver/pgdriver/config_tls_test.go
+++ b/driver/pgdriver/config_tls_test.go
@@ -1,0 +1,37 @@
+package pgdriver
+
+import "testing"
+
+func TestWithInsecure_TLSVerification(t *testing.T) {
+	// WithInsecure(false): TLS enabled AND certificate verification on.
+	conf := &Config{}
+	WithInsecure(false)(conf)
+	if conf.TLSConfig == nil {
+		t.Fatal("WithInsecure(false): TLSConfig is nil, want a verifying config")
+	}
+	if conf.TLSConfig.InsecureSkipVerify {
+		t.Fatal("WithInsecure(false): InsecureSkipVerify is true, want false (verified)")
+	}
+
+	// WithInsecure(true): plaintext, no TLS.
+	conf = &Config{}
+	WithInsecure(true)(conf)
+	if conf.TLSConfig != nil {
+		t.Fatalf("WithInsecure(true): TLSConfig = %v, want nil (plaintext)", conf.TLSConfig)
+	}
+}
+
+func TestHostWithoutPort(t *testing.T) {
+	tests := map[string]string{
+		"localhost:5432":      "localhost",
+		"db.example.com:5432": "db.example.com",
+		"localhost":           "localhost",
+		"[::1]:5432":          "::1",
+		"192.168.1.10:5432":   "192.168.1.10",
+	}
+	for in, want := range tests {
+		if got := hostWithoutPort(in); got != want {
+			t.Errorf("hostWithoutPort(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/driver/pgdriver/proto.go
+++ b/driver/pgdriver/proto.go
@@ -125,6 +125,13 @@ func enableSSL(ctx context.Context, cn *Conn, tlsConf *tls.Config) error {
 		return errors.New("pgdriver: SSL is not enabled on the server")
 	}
 
+	// A verifying config needs a ServerName; derive it from the address if the
+	// caller did not set one (e.g. the config produced by WithInsecure(false)).
+	if !tlsConf.InsecureSkipVerify && tlsConf.ServerName == "" {
+		tlsConf = tlsConf.Clone()
+		tlsConf.ServerName = hostWithoutPort(cn.conf.Addr)
+	}
+
 	tlsCN := tls.Client(cn.netConn, tlsConf)
 	if err := tlsCN.HandshakeContext(ctx); err != nil {
 		return fmt.Errorf("pgdriver: TLS handshake failed: %w", err)


### PR DESCRIPTION
## What

Makes `pgdriver.WithInsecure(false)` produce a TLS connection that **verifies the server
certificate**, instead of one that silently skips verification.

Addresses the `WithInsecure(false)` part of #1398.

## Why

```go
func WithInsecure(on bool) Option {
	if on {
		conf.TLSConfig = nil                                  // plaintext
	} else {
		conf.TLSConfig = &tls.Config{InsecureSkipVerify: true} // TLS, but UNVERIFIED
	}
}
```

A developer calling `WithInsecure(false)` to get a *secure* connection still got one with
no server authentication — open to active man-in-the-middle. There was also no option-based
way to obtain a verified connection (only `WithTLSConfig` or DSN `sslmode=verify-full`).

## Change

- `WithInsecure(false)` now returns a verifying `*tls.Config` (`&tls.Config{}`,
  `InsecureSkipVerify: false`). `WithInsecure(true)` is unchanged (plaintext).
- `enableSSL` populates `ServerName` from the connection address when a verifying config
  doesn't set one (crypto/tls requires `ServerName` or `InsecureSkipVerify`).
- Doc comment + migration note: to intentionally skip verification (self-signed cert in
  dev), pass `WithTLSConfig(&tls.Config{InsecureSkipVerify: true})`.

## Compatibility

This is a **security-motivated behavior change**: code that relied on `WithInsecure(false)`
to connect to a server with an untrusted/self-signed certificate will now fail the TLS
handshake and must opt into skipping verification explicitly (see above). Flagging clearly
for review.

## Deliberately out of scope (separate follow-ups, want maintainer input)

- Changing the package **default** (`newDefaultConfig` still uses `InsecureSkipVerify: true`);
  flipping it would break local/dev connections to self-signed servers.
- Adding **SCRAM-SHA-256-PLUS** channel binding (currently ignored in `authSASL`); it needs
  wiring the TLS connection state into the SASL client and integration testing.
- Gating `AuthenticationCleartextPassword` behind verified TLS.

## Tests

`driver/pgdriver/config_tls_test.go`: asserts `WithInsecure(false)` yields a verifying
config and `WithInsecure(true)` yields plaintext, plus `hostWithoutPort` cases. `go build`,
`go vet`, `gofmt` clean.
