### PR TITLE
fix(schema): escape backslash in AppendJSON without consuming the next byte

### DIFF
--- a/schema/appendjson_test.go
+++ b/schema/appendjson_test.go
@@ -1,0 +1,49 @@
+package schema
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestBaseDialectAppendJSON(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		// A backslash immediately followed by a single quote must NOT produce an
+		// un-doubled quote (which would break out of the SQL string literal).
+		{`{"x":"a\'; DROP TABLE t; --"}`, `'{"x":"a\''; DROP TABLE t; --"}'`},
+		// Valid encoding/json escapes are preserved.
+		{`{"k":"a\"b\\c"}`, `'{"k":"a\"b\\c"}'`},
+		// A raw single quote is doubled for SQL.
+		{`{"k":"it's"}`, `'{"k":"it''s"}'`},
+	}
+
+	for _, tt := range tests {
+		got := string(BaseDialect{}.AppendJSON(nil, []byte(tt.in)))
+		if got != tt.want {
+			t.Errorf("AppendJSON(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// The default ORM path pre-marshals with encoding/json, which never emits the
+// byte pair `\'`; such output must embed verbatim (only wrapped in quotes here,
+// since these values contain no single quote).
+func TestBaseDialectAppendJSON_EncodingJSONRoundTrips(t *testing.T) {
+	for _, v := range []any{
+		map[string]string{"msg": `a"b\c/d`},
+		map[string]string{"path": `C:\tmp\x`},
+		[]string{"line1\nline2", "tab\tend"},
+	} {
+		jsonb, err := json.Marshal(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := string(BaseDialect{}.AppendJSON(nil, jsonb))
+		want := "'" + string(jsonb) + "'"
+		if got != want {
+			t.Errorf("AppendJSON(%s) = %s, want %s", jsonb, got, want)
+		}
+	}
+}

--- a/schema/dialect.go
+++ b/schema/dialect.go
@@ -124,10 +124,11 @@ func (BaseDialect) AppendJSON(b, jsonb []byte) []byte {
 			if p.CutPrefix([]byte("u0000")) {
 				b = append(b, `\\u0000`...)
 			} else {
+				// Emit the backslash but do NOT consume the next byte here: let
+				// the loop escape it. Consuming it raw bypassed the '' quote
+				// doubling, so a "\'" byte pair produced an un-doubled quote that
+				// could break out of the SQL string literal.
 				b = append(b, '\\')
-				if p.Valid() {
-					b = append(b, p.Read())
-				}
 			}
 		default:
 			b = append(b, c)


### PR DESCRIPTION
## What

Fixes `BaseDialect.AppendJSON` so a backslash in the JSON payload can no longer
produce an un-doubled single quote that breaks out of the SQL string literal.

Closes #1403.

## Why

`AppendJSON` emitted a backslash and then copied the *next* byte verbatim, which
bypassed the `''` single-quote doubling. A `\'` byte pair therefore became `\'`
in the output — a backslash followed by an un-doubled quote that, under
`standard_conforming_strings=on` (the default), terminates the literal early:

```
BaseDialect.AppendJSON(`{"x":"a\'; DROP TABLE t; --"}`)
// before: '{"x":"a\'; DROP TABLE t; --"}'   -> ' after \ closes the literal
// after:  '{"x":"a\''; DROP TABLE t; --"}'  -> quote doubled, stays in the literal
```

The default ORM path pre-marshals with `encoding/json` (which never emits `\'`),
so it is unaffected; the bug is reachable via a custom `bunjson.Provider` or a
direct `Dialect.AppendJSON` call with non-canonical bytes.

## Change

In the `case '\\'` branch, emit only the backslash and let the main loop process
the following byte, so a subsequent single quote goes through the `''` doubling.
Valid `encoding/json` escapes (`\"`, `\\`, `\n`, …) are preserved and the jsonb
NUL-codepoint (``) rewrite is unchanged. This matches how the MySQL
dialect already handles backslashes.

## Tests

`schema/appendjson_test.go`: asserts the `\'` breakout is neutralized, that valid
JSON escapes round-trip, and that `encoding/json` output embeds unchanged. Full
`go test ./internal/... ./schema/... .`, `-race`, `GOOS=linux GOARCH=386`,
`go vet`, and `gofmt` all pass; `TestPostgresJSONB` and the `TestPostgres*`
integration suite pass against a live PostgreSQL.
