### PR TITLE
fix(schema): fail closed when a string contains a NUL byte

### DIFF
--- a/schema/appendstring_nul_test.go
+++ b/schema/appendstring_nul_test.go
@@ -1,0 +1,32 @@
+package schema
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBaseDialectAppendString_NulFailsClosed(t *testing.T) {
+	// A NUL byte must NOT be silently stripped; it must produce a formatting
+	// error marker so the query fails instead of storing a mutated value.
+	got := string(BaseDialect{}.AppendString(nil, "admin\x00x"))
+	if strings.Contains(got, "adminx") {
+		t.Fatalf("NUL was silently stripped: %q", got)
+	}
+	if !strings.Contains(got, "?!(") {
+		t.Fatalf("AppendString with NUL = %q, want a formatting error marker", got)
+	}
+}
+
+func TestBaseDialectAppendString_NoNul(t *testing.T) {
+	tests := map[string]string{
+		"abc":   `'abc'`,
+		"it's":  `'it''s'`,
+		"a\\b":  `'a\b'`, // backslash left as-is (standard_conforming_strings=on)
+		"héllo": `'héllo'`,
+	}
+	for in, want := range tests {
+		if got := string(BaseDialect{}.AppendString(nil, in)); got != want {
+			t.Errorf("AppendString(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/schema/dialect.go
+++ b/schema/dialect.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"database/sql"
 	"encoding/hex"
+	"errors"
 	"strconv"
 	"time"
 	"unicode/utf8"
@@ -11,6 +12,11 @@ import (
 	"github.com/uptrace/bun/dialect/feature"
 	"github.com/uptrace/bun/internal/parser"
 )
+
+// errStringNul is reported when a string value contains a NUL byte (0x00).
+// Silently stripping it (the previous behavior) would store a value different
+// from the one the caller supplied; PostgreSQL rejects NUL in text outright.
+var errStringNul = errors.New("bun: string contains a NUL byte (0x00)")
 
 type Dialect interface {
 	Init(db *sql.DB)
@@ -67,7 +73,9 @@ func (BaseDialect) AppendString(b []byte, s string) []byte {
 	b = append(b, '\'')
 	for _, r := range s {
 		if r == '\000' {
-			continue
+			// Fail closed instead of silently dropping the NUL, which would
+			// persist a value different from the one that was validated.
+			return dialect.AppendError(b, errStringNul)
 		}
 
 		if r == '\'' {


### PR DESCRIPTION
## What

Makes `BaseDialect.AppendString` fail closed when a string value contains a NUL
byte (0x00) instead of silently stripping it.

Closes #1404.

## Why

`AppendString` dropped NUL bytes silently, so the value bun persisted differed
from the value the application validated. That validate-vs-store divergence is a
filter/uniqueness bypass class — e.g. a username `admin\x00x` (or `admin\x00`)
passes an app-level uniqueness/denylist check as distinct from `admin`, then gets
stored as `adminx` / `admin`. PostgreSQL rejects NUL in `text` outright, so the
silent strip also masked a server-side error.

## Change

On encountering a NUL, report a formatting error via `dialect.AppendError`
(the same mechanism used for other un-formattable values), so the query fails
rather than mutating the value. This is a **behavior change**: values containing
NUL that previously "succeeded" (with the NUL removed) now error. It matches the
project's "prefer failing over silent success" review standard.

Scope: this changes `schema.BaseDialect.AppendString`, used by the pg, sqlite,
oracle, and mssql(base) dialects. The MySQL dialect's own `AppendString` and
`AppendJSON` still strip NUL and are left as follow-ups (MySQL text can legally
contain NUL, so the right behavior there needs a separate decision).

## Tests

`schema/appendstring_nul_test.go`: asserts a NUL yields a formatting-error marker
(not a stripped value) and that ordinary strings (quotes, backslashes, UTF-8) are
unaffected. `go test ./internal/... ./schema/... .`, `-race`,
`GOOS=linux GOARCH=386`, `go vet`, `gofmt` all pass; the `TestPostgres*`
integration suite passes against a live PostgreSQL.
