### PR TITLE
chore: replace go-hex with encoding/hex

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/puzpuzpuz/xsync/v3 v3.5.1
 	github.com/rs/zerolog v1.34.0
 	github.com/stretchr/testify v1.8.1
-	github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,6 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc h1:9lRDQMhESg+zvGYmW5DyG0UqvY96Bu5QYsTLvCHdrgo=
-github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc/go.mod h1:bciPuU6GHm1iF1pBvUfxfsH0Wmnc2VbpgvbI9ZWuIRs=
 github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=

--- a/internal/hex.go
+++ b/internal/hex.go
@@ -1,8 +1,6 @@
 package internal
 
-import (
-	fasthex "github.com/tmthrgd/go-hex"
-)
+import "encoding/hex"
 
 type HexEncoder struct {
 	b       []byte
@@ -27,8 +25,8 @@ func (enc *HexEncoder) Write(b []byte) (int, error) {
 	}
 
 	i := len(enc.b)
-	enc.b = append(enc.b, make([]byte, fasthex.EncodedLen(len(b)))...)
-	fasthex.Encode(enc.b[i:], b)
+	enc.b = append(enc.b, make([]byte, hex.EncodedLen(len(b)))...)
+	hex.Encode(enc.b[i:], b)
 
 	return len(b), nil
 }

--- a/internal/hex_test.go
+++ b/internal/hex_test.go
@@ -1,0 +1,55 @@
+package internal
+
+import "testing"
+
+func TestHexEncoder(t *testing.T) {
+	tests := []struct {
+		name   string
+		writes [][]byte
+		want   string
+	}{
+		{
+			name: "no writes",
+			want: "NULL",
+		},
+		{
+			name:   "single write",
+			writes: [][]byte{{0x00, 0xab, 0xff}},
+			want:   "'\\x00abff'",
+		},
+		{
+			name:   "multiple writes",
+			writes: [][]byte{{0x01}, {0x23, 0x45}},
+			want:   "'\\x012345'",
+		},
+		{
+			name:   "empty write",
+			writes: [][]byte{{}},
+			want:   "'\\x'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			enc := NewHexEncoder(nil)
+
+			for _, part := range tt.writes {
+				n, err := enc.Write(part)
+				if err != nil {
+					t.Fatalf("Write returned an error: %v", err)
+				}
+				if n != len(part) {
+					t.Fatalf("Write returned %d, want %d", n, len(part))
+				}
+			}
+
+			if err := enc.Close(); err != nil {
+				t.Fatalf("Close returned an error: %v", err)
+			}
+
+			if got := string(enc.Bytes()); got != tt.want {
+				t.Fatalf("encoded value = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed

- Replaced the unmaintained github.com/tmthrgd/go-hex dependency with Go's standard encoding/hex package
- Removed go-hex from the root module dependencies
- Added regression coverage for empty, single, and incremental writes

The two packages expose compatible EncodedLen and Encode functions, so SQL byte encoding behavior remains unchanged while removing an abandoned supply-chain dependency.

## Testing

- go test ./internal ./schema
- go vet ./internal ./schema
- git diff --check

Fixes #1385

AI assistance was used to prepare this focused change. I reviewed the implementation and test coverage and am prepared to address review feedback.