### PR TITLE
fix(relation): do not duplicate joined models on a shared base model

### DIFF
--- a/internal/dbtest/orm_test.go
+++ b/internal/dbtest/orm_test.go
@@ -38,6 +38,7 @@ func TestORM(t *testing.T) {
 		{testHasOneRelationWithOpts},
 		{testHasManyRelationWithOpts},
 		{testM2MRelationOnEmbeddedBaseModel},
+		{testRelationsOnSharedBaseModel},
 	}
 
 	testEachDB(t, func(t *testing.T, dbName string, db *bun.DB) {
@@ -733,6 +734,133 @@ func testM2MRelationOnEmbeddedBaseModel(t *testing.T, db *bun.DB) {
 	require.NoError(t, err)
 	require.Len(t, wrapped, 2)
 	require.Len(t, wrapped[1].Items, 1)
+}
+
+// testRelationsOnSharedBaseModel checks that relations loaded on a model that is
+// reachable from several base rows are not appended once per row. See #1386.
+func testRelationsOnSharedBaseModel(t *testing.T, db *bun.DB) {
+	type Tag struct {
+		bun.BaseModel `bun:"table:tags,alias:tag"`
+
+		ID   int64 `bun:",pk"`
+		Name string
+	}
+
+	type Note struct {
+		bun.BaseModel `bun:"table:notes,alias:note"`
+
+		ID     int64 `bun:",pk"`
+		NodeID int64
+	}
+
+	type Node struct {
+		bun.BaseModel `bun:"table:nodes,alias:node"`
+
+		ID    int64   `bun:",pk"`
+		Tags  []*Tag  `bun:"m2m:node_to_tags,join:Node=Tag"`
+		Notes []*Note `bun:"rel:has-many,join:id=node_id"`
+	}
+
+	type NodeToTag struct {
+		bun.BaseModel `bun:"table:node_to_tags,alias:node_to_tag"`
+
+		NodeID int64 `bun:",pk"`
+		Node   *Node `bun:"rel:belongs-to,join:node_id=id"`
+		TagID  int64 `bun:",pk"`
+		Tag    *Tag  `bun:"rel:belongs-to,join:tag_id=id"`
+	}
+
+	type ParentNode struct {
+		bun.BaseModel `bun:"table:parent_nodes,alias:parent_node"`
+
+		ID       int64 `bun:",pk"`
+		ParentID int64
+		NodeID   int64
+		Node     *Node `bun:"rel:belongs-to,join:node_id=id"`
+	}
+
+	type Parent struct {
+		bun.BaseModel `bun:"table:parents,alias:parent"`
+
+		ID    int64         `bun:",pk"`
+		Nodes []*ParentNode `bun:"rel:has-many,join:id=parent_id"`
+	}
+
+	type Child struct {
+		bun.BaseModel `bun:"table:children,alias:child"`
+
+		ID       int64 `bun:",pk"`
+		ParentID int64
+		Parent   *Parent `bun:"rel:belongs-to,join:parent_id=id"`
+	}
+
+	db.RegisterModel((*NodeToTag)(nil))
+
+	// Every child points at the same parent, so all children end up sharing
+	// a single node: the number of children must not affect the node relations.
+	for _, numChildren := range []int{1, 2, 3} {
+		t.Run(fmt.Sprintf("children=%d", numChildren), func(t *testing.T) {
+			mustResetModel(t, ctx, db,
+				(*Tag)(nil),
+				(*Note)(nil),
+				(*Node)(nil),
+				(*NodeToTag)(nil),
+				(*ParentNode)(nil),
+				(*Parent)(nil),
+				(*Child)(nil),
+			)
+
+			_, err := db.NewInsert().
+				Model(&[]*Tag{{ID: 1, Name: "tag 1"}, {ID: 2, Name: "tag 2"}}).Exec(ctx)
+			require.NoError(t, err)
+
+			_, err = db.NewInsert().Model(&[]*Node{{ID: 1}}).Exec(ctx)
+			require.NoError(t, err)
+
+			_, err = db.NewInsert().
+				Model(&[]*NodeToTag{{NodeID: 1, TagID: 1}, {NodeID: 1, TagID: 2}}).Exec(ctx)
+			require.NoError(t, err)
+
+			_, err = db.NewInsert().
+				Model(&[]*Note{{ID: 1, NodeID: 1}, {ID: 2, NodeID: 1}}).Exec(ctx)
+			require.NoError(t, err)
+
+			_, err = db.NewInsert().Model(&[]*Parent{{ID: 1}}).Exec(ctx)
+			require.NoError(t, err)
+
+			_, err = db.NewInsert().
+				Model(&[]*ParentNode{{ID: 1, ParentID: 1, NodeID: 1}}).Exec(ctx)
+			require.NoError(t, err)
+
+			children := make([]*Child, 0, numChildren)
+			for i := 1; i <= numChildren; i++ {
+				children = append(children, &Child{ID: int64(i), ParentID: 1})
+			}
+			_, err = db.NewInsert().Model(&children).Exec(ctx)
+			require.NoError(t, err)
+
+			var out []*Child
+			err = db.NewSelect().
+				Model(&out).
+				Relation("Parent").
+				Relation("Parent.Nodes").
+				Relation("Parent.Nodes.Node").
+				Relation("Parent.Nodes.Node.Tags").
+				Relation("Parent.Nodes.Node.Notes").
+				Scan(ctx)
+			require.NoError(t, err)
+			require.Len(t, out, numChildren)
+
+			for i, child := range out {
+				require.Len(t, child.Parent.Nodes, 1, "child %d", i)
+
+				node := child.Parent.Nodes[0].Node
+				require.NotNil(t, node, "child %d", i)
+				require.Len(t, node.Tags, 2, "child %d", i)
+				require.Len(t, node.Notes, 2, "child %d", i)
+			}
+		})
+	}
 }
 
 type Genre struct {

--- a/model_table_has_many.go
+++ b/model_table_has_many.go
@@ -144,12 +144,33 @@ func baseValues(model TableModel, fields []*schema.Field) map[internal.MapKey][]
 	fieldIndex := model.Relation().Field.Index
 	m := make(map[internal.MapKey][]reflect.Value)
 	key := make([]any, 0, len(fields))
+	seen := make(map[baseValueKey]struct{})
 	walk(model.rootValue(), model.parentIndex(), func(v reflect.Value) {
+		dest := v.FieldByIndex(fieldIndex)
 		key = modelKey(key[:0], v, fields)
 		mapKey := internal.NewMapKey(key)
-		m[mapKey] = append(m[mapKey], v.FieldByIndex(fieldIndex))
+		// The same struct can be reachable more than once, for example when several
+		// base models share a pointer to it. Joined models are appended to the
+		// destination field, so collecting it twice for the same key would
+		// duplicate them.
+		if dest.CanAddr() {
+			seenKey := baseValueKey{mapKey: mapKey, dest: dest.Addr().Interface()}
+			if _, ok := seen[seenKey]; ok {
+				return
+			}
+			seen[seenKey] = struct{}{}
+		}
+		m[mapKey] = append(m[mapKey], dest)
 	})
 	return m
+}
+
+// baseValueKey identifies a destination field already collected for a base model
+// key. Models that share a destination field but not the key still need their own
+// entry, so both parts are required.
+type baseValueKey struct {
+	mapKey internal.MapKey
+	dest   any
 }
 
 func modelKey(key []any, strct reflect.Value, fields []*schema.Field) []any {


### PR DESCRIPTION
baseValues walks every base model reachable from the root value and collects the relation's destination field. When several base rows point at the same struct, the same destination field was collected more than once, and because joined models are appended the relation ended up with one copy per referencing row.

Skip a destination field that was already collected for the same base model key. Keying on the field alone is not enough: base models that share a destination field but have different keys still need their own entry.

This affects has-many as well as m2m relations.

Fixes #1386