### PR TITLE
perf(schema): memoize LookupField for prefixed column names

### DIFF
--- a/schema/table.go
+++ b/schema/table.go
@@ -422,8 +422,7 @@ func (t *Table) LookupField(name string) *Field {
 	}
 
 	if v, ok := t.lookupCache.Load(name); ok {
-		field, _ := v.(*Field)
-		return field
+		return v.(*Field)
 	}
 
 	field := t.lookupFieldSlow(name)

--- a/schema/table.go
+++ b/schema/table.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/jinzhu/inflection"
@@ -38,6 +39,11 @@ func SetTableNameInflector(fn func(string) string) {
 // Table represents a SQL table created from Go struct.
 type Table struct {
 	dialect Dialect
+
+	// lookupCache memoizes LookupField results for dotted/prefixed column
+	// names (e.g. "author__name"). Those names miss FieldMap and take the
+	// slow path below, which clones the Field on every call.
+	lookupCache sync.Map // map[string]*Field
 
 	Type      reflect.Type
 	ZeroValue reflect.Value // reflect.Struct
@@ -401,11 +407,31 @@ func (t *Table) addField(field *Field) {
 	}
 }
 
+// LookupField returns the field for the given column name. Names may address
+// fields of embedded/joined structs using the "__" separator, for example
+// "author__name".
+//
+// The result is memoized: resolving a prefixed name walks StructMap and clones
+// the field with a rewritten index, and Scan calls this for every column of
+// every row. The returned *Field is treated as read-only by callers, which is
+// already assumed for the FieldMap fast path above, so the value is safe to
+// share.
 func (t *Table) LookupField(name string) *Field {
 	if field, ok := t.FieldMap[name]; ok {
 		return field
 	}
 
+	if v, ok := t.lookupCache.Load(name); ok {
+		field, _ := v.(*Field)
+		return field
+	}
+
+	field := t.lookupFieldSlow(name)
+	t.lookupCache.Store(name, field)
+	return field
+}
+
+func (t *Table) lookupFieldSlow(name string) *Field {
 	table := t
 	var index []int
 	for {

--- a/schema/table_lookup_bench_test.go
+++ b/schema/table_lookup_bench_test.go
@@ -1,0 +1,70 @@
+package schema
+
+import (
+	"reflect"
+	"testing"
+)
+
+type benchCountry struct {
+	ID   int64 `bun:",pk"`
+	Name string
+}
+
+type benchAuthor struct {
+	ID        int64 `bun:",pk"`
+	Name      string
+	Email     string
+	CountryID int64
+	Country   *benchCountry `bun:"rel:belongs-to,join:country_id=id"`
+}
+
+type benchBook struct {
+	ID       int64 `bun:",pk"`
+	Title    string
+	Subtitle string
+	AuthorID int64
+	Author   *benchAuthor `bun:"rel:belongs-to,join:author_id=id"`
+}
+
+// LookupField is called once per column per scanned row. Names that address a
+// joined struct ("author__name") miss FieldMap and take the slow path, which
+// walks StructMap and clones the field on every call.
+func BenchmarkLookupFieldPrefixed(b *testing.B) {
+	table := NewTables(newNopDialect()).Get(reflect.TypeFor[*benchBook]())
+
+	names := []string{
+		"author__id",
+		"author__name",
+		"author__email",
+		"author__country__id",
+		"author__country__name",
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, name := range names {
+			if f := table.LookupField(name); f == nil {
+				b.Fatalf("field not found: %s", name)
+			}
+		}
+	}
+}
+
+// Direct hits already return a shared *Field; kept as a baseline so the two
+// paths can be compared side by side.
+func BenchmarkLookupFieldDirect(b *testing.B) {
+	table := NewTables(newNopDialect()).Get(reflect.TypeFor[*benchBook]())
+
+	names := []string{"id", "title", "subtitle", "author_id"}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, name := range names {
+			if f := table.LookupField(name); f == nil {
+				b.Fatalf("field not found: %s", name)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`Table.LookupField` is called once per column, per scanned row (`structTableModel.scanColumn`, `hasManyModel.Scan`). It has two paths:

```go
func (t *Table) LookupField(name string) *Field {
	if field, ok := t.FieldMap[name]; ok {
		return field                  // fast path: returns a shared *Field, no allocation
	}
	// slow path: walk StructMap, then...
	return field.WithIndex(index)     // clones the Field + allocates a new index slice
}
```

Any column name that addresses a joined/embedded struct — `author__name`, `league__country__translation__name` — misses `FieldMap` and takes the slow path. Those names are extremely common: every `Relation()` generates them, and applications add their own via `ColumnExpr("... AS x__y")`.

Because the result is recomputed for every row, a query that returns *N* rows with *M* prefixed columns performs *N×M* `Field` clones. Nothing about the result depends on the row — only on `(table, name)`.

## Change

Memoize the slow path in a `sync.Map` on `Table`.

This is safe: the fast path already hands out a shared `*Field` from `FieldMap`, and every `*Field` method is read-only with respect to the receiver (`ScanValue`, `AppendValue`, `Value`, … all operate on the passed `reflect.Value`). Sharing the resolved field is therefore no different from what `FieldMap` already does.

Negative results are cached too, so repeated lookups of an unknown column stay cheap.

## Benchmarks

Added `schema/table_lookup_bench_test.go`, using a `Book → Author → Country` belongs-to chain.

```
                                    ns/op      B/op     allocs/op
BenchmarkLookupFieldPrefixed-16      2411      2088          17     (before)
BenchmarkLookupFieldPrefixed-16       183         0           0     (after)

BenchmarkLookupFieldDirect-16          70         0           0     (before)
BenchmarkLookupFieldDirect-16          68         0           0     (after, unchanged)
```

~13× faster on the prefixed path, allocations gone. The direct path is untouched.

## Impact on a real application

Found while profiling a REST API backed by Bun + PostgreSQL. The endpoint lists 50 fixtures with several belongs-to and has-many relations (~620 rows scanned per request).

Heap profile over a 30-second load test:

| | total alloc | `Field.WithIndex` | GC cycles |
|---|---|---|---|
| before | 4.85 GB | 3.27 GB (65.9%) | 1077 |
| after | 1.28 GB | *not in profile* | 219 |

`Field.WithIndex` was the single largest allocation site in the whole application — larger than JSON encoding, the pgx driver and the HTTP layer combined. CPU time in `database/sql.convertAssignRows` dropped from 31.8% to 19.4%.

Endpoint responses were byte-for-byte identical across 18 scenarios (pagination, search, filters, two languages) before and after.

## Notes

- `go test ./schema/... .` and `./internal/...` pass.
- I could not run `-race` locally (no cgo toolchain on this machine); CI should cover it. `sync.Map` is used only for read-mostly caching, and a duplicate computation under a race would simply produce an equivalent `*Field`.
- The cache is bounded by the set of distinct column names a table is ever scanned with, which is bounded by the application's queries.
